### PR TITLE
chore(ci): add dependabot config and release workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      # Dependency update will be run each week on monday
+      interval: "weekly"
+    labels:
+      - "dependencies"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major" # Ignore major updates
+          - "version-update:semver-minor" # Ignore minor updates

--- a/.github/workflows/dependabot_pr.yml
+++ b/.github/workflows/dependabot_pr.yml
@@ -1,0 +1,30 @@
+name: Dependabot PR Auto Approve and Merge
+
+on:
+  pull_request:
+    types:
+      - opened
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: ${{ github.actor == 'dependabot[bot]' && github.event.label.name == 'dependencies' }}
+
+    steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v1.3.2
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Approve a PR
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+
+      - name: Enable auto merge
+        run: gh pr merge --auto --rebase "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,34 @@
+name: GHCR Release CI
+
+on:
+  push:
+    tags:
+      - "[0-9]+.[0-9]+.[0-9]+"
+
+jobs:
+  tests:
+    name: Release new Docker Image in GHCR
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{github.repository_owner}}
+          password: ${{secrets.GITHUB_TOKEN}}
+
+      - name: Build Docker images for GHCR
+        run: make build_ghcr
+
+      - name: Push Docker images to GHCR
+        run: make push_ghcr

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,8 @@ DOCKER_TAG ?= latest
 
 export DOCKER_BUILDKIT=1
 
+.DEFAULT_GOAL := help
+
 .PHONY: install
 install: ## Install npm dependencies
 	npm install

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,41 @@
+VERSION ?= $(shell git describe --always --tags)
+DOCKER_TAG ?= latest
+
+export DOCKER_BUILDKIT=1
+
+.PHONY: install
+install: ## Install npm dependencies
+	npm run build
+
+.PHONY: build
+build: install ## Build npm project
+	npm run build
+
+.PHONY: build_docker
+build_docker: ## Build docker image
+	docker build --tag=camptocamp/geoshop-front:$(VERSION) \
+		--build-arg=VERSION=$(VERSION) .
+	docker tag camptocamp/geoshop-front:$(VERSION) camptocamp/geoshop-front:$(DOCKER_TAG)
+
+.PHONY: build_ghcr
+build_ghcr: ## Build docker image tagged for GHCR
+	docker build --tag=ghcr.io/camptocamp/geoshop-front:$(VERSION) \
+		--build-arg=VERSION=$(VERSION) .
+	docker tag ghcr.io/camptocamp/geoshop-front:$(VERSION) ghcr.io/camptocamp/geoshop-front:$(DOCKER_TAG)
+
+.PHONY: push_ghcr
+push_ghcr: ## Push docker image to GHCR
+	docker push ghcr.io/camptocamp/geoshop-front:$(VERSION)
+	docker push ghcr.io/camptocamp/geoshop-front:$(DOCKER_TAG)
+
+.PHONY: test
+test: install ## Run tests
+	npm test
+
+.PHONY: help
+help: ## Display this help
+	@echo "Usage: make <target>"
+	@echo
+	@echo "Available targets:"
+	@grep --extended-regexp --no-filename '^[a-zA-Z_-]+:.*## ' $(MAKEFILE_LIST) | sort | \
+		awk 'BEGIN {FS = ":.*?## "}; {printf "	%-20s%s\n", $$1, $$2}'

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ export DOCKER_BUILDKIT=1
 
 .PHONY: install
 install: ## Install npm dependencies
-	npm run build
+	npm install
 
 .PHONY: build
 build: install ## Build npm project


### PR DESCRIPTION
Simplified CI than [geoshop-backend](https://github.com/camptocamp/geoshop-back/pull/24) one
I didn't added any test workflow since they're not working and I don't even know if they're relevant but it can be added in the future easily.
I added a dependabot config which will do security updates for dependencies but also weekly updates of all dependencies (just patch (`1.0.x`) ones, I disabled major and minor updates since there is no tests to validate the update before auto-merging)
I also added a release workflow (triggered on tag push in the format `x.y.z`) which build the Docker image, tag it for GHCR and finally push it. 