### PR TITLE
ci: fix dependabot auto-merge workflow condition

### DIFF
--- a/.github/workflows/dependabot_pr.yml
+++ b/.github/workflows/dependabot_pr.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   dependabot:
     runs-on: ubuntu-latest
-    if: ${{ github.actor == 'dependabot[bot]' && github.event.label.name == 'dependencies' }}
+    if: github.event.pull_request.user.login == 'dependabot[bot]' && contains(github.event.issue.labels.*.name, 'dependencies')
 
     steps:
       - name: Dependabot metadata


### PR DESCRIPTION
Same fix as https://github.com/camptocamp/geoshop-back/pull/34
Since I can't test it until a new dependabot PR is opened I don't know if this is a final and working fix sadly 