### PR TITLE
ci(dep): add missing permissions and second attempt to fix condition

### DIFF
--- a/.github/workflows/dependabot_pr.yml
+++ b/.github/workflows/dependabot_pr.yml
@@ -4,11 +4,18 @@ on:
   pull_request:
     types:
       - opened
+      - synchronize
+      - reopened
+      - labeled
+
+permissions:
+  contents: write
+  pull-requests: write
 
 jobs:
   dependabot:
     runs-on: ubuntu-latest
-    if: github.event.pull_request.user.login == 'dependabot[bot]' && contains(github.event.issue.labels.*.name, 'dependencies')
+    if: github.actor == 'dependabot[bot]' && contains(github.event.pull_request.labels.*.name, 'dependencies')
 
     steps:
       - name: Dependabot metadata


### PR DESCRIPTION
Unfortunately the condition for the dependabot auto-merge isn't fixed...
Hope this second attempt will be the last one :crossed_fingers: 