### PR TITLE
feat: GSGGR-240 Add feature flag for username/password authentication

### DIFF
--- a/src/app/_components/account-overlay/account-overlay.component.html
+++ b/src/app/_components/account-overlay/account-overlay.component.html
@@ -27,7 +27,7 @@
 
 </ng-container>
 
-<ng-container *ngIf="!(isLoggedIn$|async)">
+<ng-container *ngIf="!(isLoggedIn$|async) && localAuthEnabled">
   <div class="flex-row px-16">
     <mat-icon class="overflow">info</mat-icon>
     <span i18n="@@account.auth_required">Pour commander vous devez obligatoirement vous authentifier.</span>
@@ -39,5 +39,11 @@
   <button mat-button color="primary" [routerLink]="['auth/register']">
       <mat-icon>person_add</mat-icon>
       <span i18n="@@account.create_account">Créer un compte</span>
+  </button>
+</ng-container>
+
+<ng-container  *ngIf="!(isLoggedIn$|async) && !localAuthEnabled">
+  <button *ngIf="oidcEnabled" i18n="@@login.login_oidc" class="form-login-button" color="primary" mat-raised-button (click)="oidcAuthClick()" >
+    Login with Zitadel
   </button>
 </ng-container>

--- a/src/app/_components/account-overlay/account-overlay.component.html
+++ b/src/app/_components/account-overlay/account-overlay.component.html
@@ -42,8 +42,11 @@
   </button>
 </ng-container>
 
-<ng-container  *ngIf="!(isLoggedIn$|async) && !localAuthEnabled">
-  <button *ngIf="oidcEnabled" i18n="@@login.login_oidc" class="form-login-button" color="primary" mat-raised-button (click)="oidcAuthClick()" >
-    Login with Zitadel
-  </button>
-</ng-container>
+<button *ngIf="!(isLoggedIn$|async) && !localAuthEnabled && oidcEnabled" mat-button color="primary" (click)="oidcAuthClick()" >
+  <mat-icon>input</mat-icon>
+  <span i18n="@@login.login_oidc">OIDC S'authentifier</span>
+</button>
+
+<span *ngIf="!localAuthEnabled && !oidcEnabled" i18n="@@login.no_auth_available">
+  Aucune méthode d'authentification disponible
+</span>

--- a/src/app/_components/account-overlay/account-overlay.component.ts
+++ b/src/app/_components/account-overlay/account-overlay.component.ts
@@ -3,6 +3,8 @@ import {Store} from '@ngrx/store';
 import {AppState, getUser, isLoggedIn} from '../../_store';
 import * as fromAuth from '../../_store/auth/auth.action';
 import * as fromCart from '../../_store/cart/cart.action';
+import { ConfigService } from 'src/app/_services/config.service';
+import { OidcSecurityService } from 'angular-auth-oidc-client';
 
 @Component({
   selector: 'gs2-account-overlay',
@@ -16,10 +18,25 @@ export class AccountOverlayComponent implements OnInit {
   isLoggedIn$ = this.store.select(isLoggedIn);
   user$ = this.store.select(getUser);
 
-  constructor(private store: Store<AppState>) {
+  constructor(
+    private store: Store<AppState>,
+    private readonly config: ConfigService,
+    private readonly oidcSecurityService: OidcSecurityService) {
   }
 
   ngOnInit(): void {
+  }
+
+  get oidcEnabled():boolean {
+    return this.config.config?.oidcConfig ? true : false;
+  }
+
+  get localAuthEnabled():boolean {
+    return this.config.config?.localAuthEnabled ? true: false;
+  }
+
+  oidcAuthClick() {
+    this.oidcSecurityService.authorize();
   }
 
   logout() {

--- a/src/app/_models/IConfig.ts
+++ b/src/app/_models/IConfig.ts
@@ -24,6 +24,7 @@ export interface IConfig {
   epsg: string;
   pageformats: Array<IPageFormat>;
   oidcConfig: OpenIdConfiguration;
+  localAuthEnabled: boolean;
 }
 
 export interface IPageFormat {

--- a/src/app/auth/login/login.component.html
+++ b/src/app/auth/login/login.component.html
@@ -3,7 +3,7 @@
     <mat-card-title i18n="@@login.auth_title">GeoShop - Authentification</mat-card-title>
     <mat-card-subtitle>{{ LOGIN }}</mat-card-subtitle>
   </mat-card-header>
-  <mat-card-content>
+  <mat-card-content *ngIf="localAuthEnabled">
     <form [formGroup]="form" (ngSubmit)="submit()">
       <mat-form-field color="primary">
         <input formControlName="username"
@@ -33,6 +33,13 @@
       <button mat-button color="accent" [routerLink]="'/auth/forget'" class="flex-row forgotten-button" >
         <span i18n="@@login.pw_forgotten">Mot de passe oublié</span>
         <mat-icon>help_outline</mat-icon>
+      </button>
+    </form>
+  </mat-card-content>
+  <mat-card-content *ngIf="!localAuthEnabled && oidcEnabled">
+    <form>
+      <button *ngIf="oidcEnabled" i18n="@@login.login_oidc" class="form-login-button" color="primary" mat-raised-button (click)="oidcAuthClick()" >
+        Login with Zitadel
       </button>
     </form>
   </mat-card-content>

--- a/src/app/auth/login/login.component.ts
+++ b/src/app/auth/login/login.component.ts
@@ -36,7 +36,6 @@ export class LoginComponent implements OnInit {
   }
 
   private callbackUrl: string;
-  private hasClickOnLogin = false;
 
   constructor(private store: Store<AppState>, private route: ActivatedRoute,
               private el: ElementRef,
@@ -63,7 +62,6 @@ export class LoginComponent implements OnInit {
         },
         callbackUrl: this.callbackUrl,
       };
-      this.hasClickOnLogin = true;
       this.store.dispatch(AuthActions.login(payload));
     }
   }
@@ -72,8 +70,11 @@ export class LoginComponent implements OnInit {
     return this.config.config?.oidcConfig ? true : false;
   }
 
+  get localAuthEnabled():boolean {
+    return this.config.config?.localAuthEnabled ? true: false;
+  }
+
   oidcAuthClick() {
-    this.hasClickOnLogin = true;
     this.oidcSecurityService.authorize();
   }
 }

--- a/src/assets/configs/config.json.tmpl
+++ b/src/assets/configs/config.json.tmpl
@@ -69,7 +69,7 @@
       "height": 1189
     }
   ],
-  "localAuthEnabled": false,
+  "localAuthEnabled": ${LOCAL_AUTH_ENABLED},
   "oidcConfig": {
     "customParamsAuthRequest": {
         "prompt": "select_account"

--- a/src/assets/configs/config.json.tmpl
+++ b/src/assets/configs/config.json.tmpl
@@ -69,6 +69,7 @@
       "height": 1189
     }
   ],
+  "localAuthEnabled": false,
   "oidcConfig": {
     "customParamsAuthRequest": {
         "prompt": "select_account"

--- a/src/locale/messages.de.xlf
+++ b/src/locale/messages.de.xlf
@@ -66,6 +66,31 @@
           <context context-type="linenumber">45</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="login.login_oidc" datatype="html">
+        <source>OIDC S&apos;authentifier</source>
+        <target>OIDC Anmelden</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/_components/account-overlay/account-overlay.component.html</context>
+          <context context-type="linenumber">47</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/auth/login/login.component.html</context>
+          <context context-type="linenumber">30,32</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/auth/login/login.component.html</context>
+          <context context-type="linenumber">41,43</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="login.no_auth_available" datatype="html">
+        <source> Aucune méthode d&apos;authentification disponible
+</source>
+        <target>Keine Authentifizierungsmethoden vorhanden</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/_components/account-overlay/account-overlay.component.html</context>
+          <context context-type="linenumber">50,52</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="cart.empty" datatype="html">
         <source>Vider le panier</source>
         <target>Warenkorb leeren</target>

--- a/src/locale/messages.de.xlf
+++ b/src/locale/messages.de.xlf
@@ -68,7 +68,7 @@
       </trans-unit>
       <trans-unit id="login.login_oidc" datatype="html">
         <source>OIDC S&apos;authentifier</source>
-        <target>OIDC Anmelden</target>
+        <target>Anmelden mit OIDC</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/_components/account-overlay/account-overlay.component.html</context>
           <context context-type="linenumber">47</context>
@@ -960,7 +960,7 @@
       </trans-unit>
       <trans-unit id="login.login_oidc" datatype="html">
         <source>Login with Zitadel</source>
-        <target>Login with Zitadel</target>
+        <target>Anmelden mit OIDC</target>
       </trans-unit>
       <trans-unit id="df9d935c95f3e8eda64cfd0967fbb9cb358409e4" datatype="html">
         <source>Mot de passe</source>

--- a/src/locale/messages.xlf
+++ b/src/locale/messages.xlf
@@ -44,6 +44,29 @@
           <context context-type="linenumber">41</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="login.login_oidc" datatype="html">
+        <source>OIDC S&apos;authentifier</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/_components/account-overlay/account-overlay.component.html</context>
+          <context context-type="linenumber">47</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/auth/login/login.component.html</context>
+          <context context-type="linenumber">30,32</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/auth/login/login.component.html</context>
+          <context context-type="linenumber">41,43</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="login.no_auth_available" datatype="html">
+        <source> Aucune méthode d&apos;authentification disponible
+</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/_components/account-overlay/account-overlay.component.html</context>
+          <context context-type="linenumber">50,52</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="cart.empty" datatype="html">
         <source> Vider le panier
 </source>
@@ -924,13 +947,6 @@
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/auth/reset/reset.component.html</context>
           <context context-type="linenumber">13</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="login.login_oidc" datatype="html">
-        <source> Login with Zitadel </source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/auth/login/login.component.html</context>
-          <context context-type="linenumber">30,32</context>
         </context-group>
       </trans-unit>
       <trans-unit id="login.pw_forgotten" datatype="html">


### PR DESCRIPTION
Works like this: 
1. If both OIDC and Login/Password are enabled, then "Login" button will redirect to a regular login page with Username and Password fields and "Login with Zitadel" button
2. If only OIDC is enabled then "Login" button will trigger Zitadel auth
3. If none is eabled, there will be an message that there is no authentication enabled.