### PR TITLE
fix(GSGGR-245): Better fit of an initial area

### DIFF
--- a/src/app/_services/map.service.ts
+++ b/src/app/_services/map.service.ts
@@ -158,7 +158,8 @@ export class MapService {
       this.route.queryParamMap.subscribe(params => {
         const bounds = params.get("bounds")?.split(",", -1).map(parseFloat)
         if (bounds) {
-          this.map.getView().fit(new Polygon([[[bounds[0], bounds[1]], [bounds[2], bounds[3]]]]));
+          this.map.getView().fit(new Polygon([[[bounds[0], bounds[1]], [bounds[2], bounds[3]]]]),
+            { nearest: true });
         }
       });
     });


### PR DESCRIPTION
Now geoshop displays initial area more similar to the one from geoportal:
![geoviewer](https://github.com/user-attachments/assets/5b332360-0997-4ed9-af05-4a7762be622e)
![geoshop](https://github.com/user-attachments/assets/b7abf03e-119b-4484-8644-6be3ec83d231)
