### PR TITLE
Defining search configuration with the environment variables

### DIFF
--- a/src/app/_models/IConfig.ts
+++ b/src/app/_models/IConfig.ts
@@ -9,18 +9,25 @@ export interface IBasemap {
   format: string;
 }
 
+export interface ISearchConfig {
+  url: string;
+  queryParamName: string;
+  querySuffix: string;
+  layers: string;
+}
+
 // TODO it look like thie interface is never used -> remove it or use it!
 export interface IConfig {
   apiUrl: string;
   mediaUrl: string;
   baseMapUrl: string;
-  geocoderUrl: string;
-  geocoderLayers: string[];
+  search: ISearchConfig;
   contact: {
     links: { conditions: string; tariffs: string; };
     phone: { label: string; number: string };
     email: string;
   };
+
   basemaps: Array<IBasemap>;
   initialCenter: number[];
   initialExtent: number[];

--- a/src/app/_models/IConfig.ts
+++ b/src/app/_models/IConfig.ts
@@ -14,6 +14,7 @@ export interface ISearchConfig {
   queryParamName: string;
   querySuffix: string;
   layers: string;
+  providerType: string;
 }
 
 // TODO it look like thie interface is never used -> remove it or use it!

--- a/src/app/_services/map.service.ts
+++ b/src/app/_services/map.service.ts
@@ -319,17 +319,13 @@ export class MapService {
       return of([]);
     }
     const coordinateResult = this.coordinateSearchService.stringCoordinatesToFeature(inputText);
-    const urlText = this.configService.config?.geocoderUrl;
-    if (!urlText) {
+    const searchConfig = this.configService.config?.search;
+    if (!searchConfig) {
       return of([]);
     }
-    const url = new URL(urlText);
-    url.searchParams.append('searchText', inputText);
-    url.searchParams.append('limit', '5');  // TODO find a good limit for this
-    url.searchParams.append('geometryFormat', 'geojson');
-    url.searchParams.append('type', 'locations');
-    url.searchParams.append('sr', '2056');
-    url.searchParams.append('origins', 'district,gg25,parcel,address');
+    const url = new URL(searchConfig.url);
+    url.searchParams.append(searchConfig.queryParamName, inputText);
+    url.search += `&${searchConfig.querySuffix}`;
     return this.httpClient.get(url.toString()).pipe(
       map((featureCollectionData) => {
         const featureCollection = this.geoJsonFormatter.readFeatures(featureCollectionData);

--- a/src/app/_services/map.service.ts
+++ b/src/app/_services/map.service.ts
@@ -39,7 +39,7 @@ import { BehaviorSubject, of } from 'rxjs';
 import { formatArea } from '../_helpers/geoHelper';
 import proj4 from 'proj4';
 import { HttpClient } from '@angular/common/http';
-import { map, switchMap } from 'rxjs/operators';
+import { switchMap } from 'rxjs/operators';
 import { IBasemap, IPageFormat } from '../_models/IConfig';
 import { AppState, selectOrder } from '../_store';
 import { select, Store } from '@ngrx/store';
@@ -47,7 +47,6 @@ import { updateGeometry } from '../_store/cart/cart.action';
 import { DragAndDropEvent } from 'ol/interaction/DragAndDrop';
 import { shiftKeyOnly } from 'ol/events/condition';
 import { createBox } from 'ol/interaction/Draw';
-import { CoordinateSearchService } from './coordinate-search.service';
 import { ActivatedRoute } from '@angular/router';
 import { getArea as getAreaSphere } from 'ol/sphere.js';
 import { ApiOrderService } from './api-order.service';
@@ -146,10 +145,8 @@ export class MapService {
     private configService: ConfigService,
     private route: ActivatedRoute,
     private apiOrderService: ApiOrderService,
-    private coordinateSearchService: CoordinateSearchService,
     private store: Store<AppState>,
-    private snackBar: MatSnackBar,
-    private httpClient: HttpClient) {
+    private snackBar: MatSnackBar) {
   }
 
   public initialize() {
@@ -312,29 +309,6 @@ export class MapService {
     tileLayer.set('thumbnail', baseMapConfig.thumbUrl);
 
     return tileLayer;
-  }
-
-  public geocoderSearch(inputText: string) {
-    if (!inputText || inputText.length === 0 || typeof inputText !== 'string') {
-      return of([]);
-    }
-    const coordinateResult = this.coordinateSearchService.stringCoordinatesToFeature(inputText);
-    const searchConfig = this.configService.config?.search;
-    if (!searchConfig) {
-      return of([]);
-    }
-    const url = new URL(searchConfig.url);
-    url.searchParams.append(searchConfig.queryParamName, inputText);
-    url.search += `&${searchConfig.querySuffix}`;
-    return this.httpClient.get(url.toString()).pipe(
-      map((featureCollectionData) => {
-        const featureCollection = this.geoJsonFormatter.readFeatures(featureCollectionData);
-        if (coordinateResult) {
-          featureCollection.push(coordinateResult);
-        }
-        return featureCollection;
-      })
-    );
   }
 
   public stripHtmlTags(html: string): string {

--- a/src/app/_services/search.service.ts
+++ b/src/app/_services/search.service.ts
@@ -1,0 +1,57 @@
+import { Injectable } from "@angular/core";
+import { ConfigService } from "./config.service";
+import { HttpClient } from "@angular/common/http";
+import { map, Observable, of } from "rxjs";
+import { Geometry } from "ol/geom";
+import { CoordinateSearchService } from "./coordinate-search.service";
+import { Feature } from "ol";
+import GeoJSON from "ol/format/GeoJSON";
+import { ISearchConfig } from "../_models/IConfig";
+
+
+@Injectable({
+  providedIn: 'root'
+})
+export class SearchService {
+  private readonly geoJsonFormatter = new GeoJSON();
+
+  constructor(
+    private readonly configService: ConfigService,
+    private readonly coordinateSearchService: CoordinateSearchService,
+    private readonly httpClient: HttpClient,
+  ) {
+
+  }
+
+  public search(query: string): Observable<Feature<Geometry>[]> {
+    if (!query || query.length === 0 || typeof query !== 'string') {
+      return of([]);
+    }
+    const searchConfig = this.configService.config?.search;
+    if (!searchConfig) {
+      return of([]);
+    }
+
+    switch (searchConfig.providerType) {
+      case 'geocoder':
+        return this.searchGeocoder(query, searchConfig);
+    }
+    return of([]);
+  }
+
+  private searchGeocoder(query: string, config: ISearchConfig) {
+    const coordinateResult = this.coordinateSearchService.stringCoordinatesToFeature(query);
+    const url = new URL(config.url);
+    url.searchParams.append(config.queryParamName, query);
+    url.search += `&${config.querySuffix}`;
+    return this.httpClient.get(url.toString()).pipe(
+      map((featureCollectionData) => {
+        const featureCollection = this.geoJsonFormatter.readFeatures(featureCollectionData);
+        if (coordinateResult) {
+          featureCollection.push(coordinateResult);
+        }
+        return featureCollection;
+      })
+    );
+  }
+}

--- a/src/app/welcome/map/map.component.ts
+++ b/src/app/welcome/map/map.component.ts
@@ -10,6 +10,7 @@ import {MatAutocompleteSelectedEvent} from '@angular/material/autocomplete';
 import Feature from 'ol/Feature';
 import {MatDialog} from '@angular/material/dialog';
 import {ManualentryComponent} from './manualentry/manualentry.component';
+import { SearchService } from 'src/app/_services/search.service';
 
 export const nameOfCategoryForGeocoder: { [prop: string]: string; } = { // TODO this should be translated
   zipcode: 'Ortschaftenverzeichnis PLZ',
@@ -66,6 +67,7 @@ export class MapComponent implements OnInit {
   constructor(private mapService: MapService,
               private configService: ConfigService,
               private customIconService: CustomIconService,
+              private readonly searchService: SearchService,
               public dialog: MatDialog) {
     // Initialize custom icons
     this.customIconService.init();
@@ -87,7 +89,7 @@ export class MapComponent implements OnInit {
             if (inputText.length === 0) {
               this.shouldDisplayClearButton = false;
             }
-            return this.mapService.geocoderSearch(inputText);
+            return this.searchService.search(inputText);
           })
         )
         .subscribe(features => {

--- a/src/assets/configs/config.json.tmpl
+++ b/src/assets/configs/config.json.tmpl
@@ -2,12 +2,12 @@
   "apiUrl": "${API_BASE_URL}/${API_ROOTURL}",
   "mediaUrl": "${MEDIA_URL}",
   "baseMapUrl": "https://wmts.geo.admin.ch/1.0.0/{layer}/{style}/current/{TileMatrixSet}/{TileMatrix}/{TileCol}/{TileRow}",
-  "geocoderUrl": "https://api3.geo.admin.ch/rest/services/api/SearchServer",
-  "geocoderLayers": [
-    "adresses_sitn", "nom_local_lieu_dit", "search_cours_eau",
-    "batiments_ofs", "axe_rue", "ImmeublesCanton", "communes", "cadastres",
-    "recenter_to"
-  ],
+  "search": {
+    "url": "${SEARCH_URL}",
+    "queryParamName": "${SEARCH_QUERY_PARAM_NAME}",
+    "querySuffix": "${SEARCH_QUERY_SUFFIX}",
+    "layers": "${SEARCH_LAYERS}",
+  },
   "contact": {
     "phone": {
       "label": "",

--- a/src/assets/configs/config.json.tmpl
+++ b/src/assets/configs/config.json.tmpl
@@ -7,6 +7,7 @@
     "queryParamName": "${SEARCH_QUERY_PARAM_NAME}",
     "querySuffix": "${SEARCH_QUERY_SUFFIX}",
     "layers": "${SEARCH_LAYERS}",
+    "providerType": "${SEARCH_PROVIDER_NAME}",
   },
   "contact": {
     "phone": {


### PR DESCRIPTION
The most simple solution for the search cofiguration: there is only one dynamic parameter - search query name, so the URL for GET request constructed like "${SEARCH_URL}?${SEARCH_QUERY_PARAM_NAME}=user input&${SEARCH_QUERY_SUFFIX}".

Not supported or partially supported features:

- Pagination: only first page, truncated to the result size
- Number of items in result: defined in the suffix
- Post requests are not supported
- Complex search request configurations are not supported