### PR TITLE
fix(GEORD-724): Fix displaying placeholders instead of real captions for the categories

### DIFF
--- a/src/app/constants.ts
+++ b/src/app/constants.ts
@@ -47,7 +47,7 @@ export const SEARCH_CATEGORY: Map<string, string> = new Map([
   ["gg25", $localize`:@@search.category.gemeinden:Communes`],
   ["district", $localize`:@@search.category.district:Districts`],
   ["kantone", $localize`:@@search.category.kanton:Cantons`],
-  ["gazetteer", $localize`:@@search.category.gazetteer:Arrêts OEV`],
+  ["gazetteer", $localize`:@@search.category.gazetteer:Transports publics`],
   ["address", $localize`:@@search.category.address:Adresses`],
   ["parcel", $localize`:@@search.category.parcel:Parcelles`],
   // Mapfish categories

--- a/src/app/constants.ts
+++ b/src/app/constants.ts
@@ -43,16 +43,17 @@ export const COUNTRIES = {
 
 export const SEARCH_CATEGORY: Map<string, string> = new Map([
   // Geocoder categories
-  ["zipcode", $localize`:@@search.category.zipcode:Ortschaftenverzeichnis PLZ`],
-  ["gg25", $localize`:@@search.category.gemeinden:Gemeinden`],
-  ["district", $localize`:@@search.category.district:Bezirke`],
-  ["kantone", $localize`:@@search.category.kanton:Kantone`],
-  ["gazetteer", $localize`:@@search.category.gazetteer:OEV Haltestellen`],
-  ["address", $localize`:@@search.category.address:Adressen`],
-  ["parcel", $localize`:@@search.category.parcel:Parzellen`],
+  ["zipcode", $localize`:@@search.category.zipcode:Code postal`],
+  ["gg25", $localize`:@@search.category.gemeinden:Communes`],
+  ["district", $localize`:@@search.category.district:Districts`],
+  ["kantone", $localize`:@@search.category.kanton:Cantons`],
+  ["gazetteer", $localize`:@@search.category.gazetteer:Arrêts OEV`],
+  ["address", $localize`:@@search.category.address:Adresses`],
+  ["parcel", $localize`:@@search.category.parcel:Parcelles`],
   // Mapfish categories
-  ["Adressen", $localize`:@@search.category.address:Adressen`],
-  ["Gemeindegrenzen", $localize`:@@search.category.gemeinden:Gemeinden`],
+  ["Adressen", $localize`:@@search.category.address:Adresses`],
+  ["Gemeindegrenzen", $localize`:@@search.category.gemeinden:Communes`],
+  ["Kantone", $localize`:@@search.category.kanton:Cantons`],
 ]);
 
-export const SEARCH_CATEGORY_GENERAL = $localize`:@@search.category.unknown:Allgemein`;
+export const SEARCH_CATEGORY_GENERAL = $localize`:@@search.category.unknown:Général`;

--- a/src/app/welcome/map/map.component.ts
+++ b/src/app/welcome/map/map.component.ts
@@ -24,16 +24,6 @@ import { ManualentryComponent } from './manualentry/manualentry.component';
 import { ISearchResult } from '@app/models/ISearch';
 import { SEARCH_CATEGORY, SEARCH_CATEGORY_GENERAL } from '@app/constants';
 
-export const nameOfCategoryForGeocoder: Record<string, string> = { // TODO this should be translated
-  "zipcode": 'Ortschaftenverzeichnis PLZ',
-  "gg25": 'Gemeinden',
-  "district": 'Bezirke',
-  "kantone": 'Kantone',
-  "gazetteer": 'OEV Haltestellen',
-  "address": 'Adressen',
-  "parcel": 'Parzellen',
-};
-
 @Component({
   selector: 'gs2-map',
   templateUrl: './map.component.html',

--- a/src/locale/messages.de.xlf
+++ b/src/locale/messages.de.xlf
@@ -1402,7 +1402,7 @@
         </context-group>
       </trans-unit>
       <trans-unit id="search.category.gemeinden" datatype="html">
-        <source>Gemeinden</source>
+        <source>Communes</source>
         <target state="new">Gemeinden</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/constants.ts</context>
@@ -1414,7 +1414,7 @@
         </context-group>
       </trans-unit>
       <trans-unit id="search.category.district" datatype="html">
-        <source>Bezirke</source>
+        <source>Districts</source>
         <target state="new">Bezirke</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/constants.ts</context>
@@ -1422,7 +1422,7 @@
         </context-group>
       </trans-unit>
       <trans-unit id="search.category.kanton" datatype="html">
-        <source>Kantone</source>
+        <source>Cantons</source>
         <target state="new">Kantone</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/constants.ts</context>
@@ -1430,7 +1430,7 @@
         </context-group>
       </trans-unit>
       <trans-unit id="search.category.gazetteer" datatype="html">
-        <source>OEV Haltestellen</source>
+        <source>Arrêts OEV</source>
         <target state="new">OEV Haltestellen</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/constants.ts</context>
@@ -1438,7 +1438,7 @@
         </context-group>
       </trans-unit>
       <trans-unit id="search.category.address" datatype="html">
-        <source>Adressen</source>
+        <source>Adresses</source>
         <target state="new">Adressen</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/constants.ts</context>
@@ -1450,7 +1450,7 @@
         </context-group>
       </trans-unit>
       <trans-unit id="search.category.parcel" datatype="html">
-        <source>Parzellen</source>
+        <source>Parcelles</source>
         <target state="new">Parzellen</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/constants.ts</context>
@@ -1849,7 +1849,7 @@
         </context-group>
       </trans-unit>
       <trans-unit id="search.category.zipcode" datatype="html">
-        <source>Ortschaftenverzeichnis PLZ</source>
+        <source>Code postal</source>
         <target state="new">Ortschaftenverzeichnis PLZ</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/constants.ts</context>

--- a/src/locale/messages.xlf
+++ b/src/locale/messages.xlf
@@ -1183,14 +1183,14 @@
         </context-group>
       </trans-unit>
       <trans-unit id="search.category.zipcode" datatype="html">
-        <source>Ortschaftenverzeichnis PLZ</source>
+        <source>Code postal</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/constants.ts</context>
           <context context-type="linenumber">46</context>
         </context-group>
       </trans-unit>
       <trans-unit id="search.category.gemeinden" datatype="html">
-        <source>Gemeinden</source>
+        <source>Communes</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/constants.ts</context>
           <context context-type="linenumber">47</context>
@@ -1201,28 +1201,28 @@
         </context-group>
       </trans-unit>
       <trans-unit id="search.category.district" datatype="html">
-        <source>Bezirke</source>
+        <source>Districts</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/constants.ts</context>
           <context context-type="linenumber">48</context>
         </context-group>
       </trans-unit>
       <trans-unit id="search.category.kanton" datatype="html">
-        <source>Kantone</source>
+        <source>Cantons</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/constants.ts</context>
           <context context-type="linenumber">49</context>
         </context-group>
       </trans-unit>
       <trans-unit id="search.category.gazetteer" datatype="html">
-        <source>OEV Haltestellen</source>
+        <source>Arrêts OEV</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/constants.ts</context>
           <context context-type="linenumber">50</context>
         </context-group>
       </trans-unit>
       <trans-unit id="search.category.address" datatype="html">
-        <source>Adressen</source>
+        <source>Adresses</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/constants.ts</context>
           <context context-type="linenumber">51</context>
@@ -1233,14 +1233,14 @@
         </context-group>
       </trans-unit>
       <trans-unit id="search.category.parcel" datatype="html">
-        <source>Parzellen</source>
+        <source>Parcelles</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/constants.ts</context>
           <context context-type="linenumber">52</context>
         </context-group>
       </trans-unit>
       <trans-unit id="search.category.unknown" datatype="html">
-        <source>Allgemein</source>
+        <source>Général</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/constants.ts</context>
           <context context-type="linenumber">58</context>


### PR DESCRIPTION
<img width="1452" height="709" alt="after-2-fr" src="https://github.com/user-attachments/assets/2039960a-3ec9-413f-9b57-2256291b5108" />
<img width="1462" height="595" alt="after-2-de" src="https://github.com/user-attachments/assets/820764c2-d5e5-4058-9dd2-c7ecb51f0ab9" />
