### PR TITLE
feat(GEORD-726): Allowing to restrict map view to some extent.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ cp src\assets\configs\config.json.tmpl src\assets\configs\config.json
 #### Some values to note:
 
 - `apiUrl` : URL to the BE/API
-- `initialCenter` : sets the initial center of the map on the langing page
+- `defaultCenter` : sets the initial center of the map on the langing page
 - `initialExten` : the extent used for the calculation of the tiels. If this is changed the `resolutions` and the logic for the calcualtion of the `MatrixId` for the tile requets needs to be adapted as well. Currentli this is a BBox that is somewhat larger than the BBox of Switzerland.
 - `basemaps` : configure the base maps that can be selected
 - `mediaUrl` : if set to an empty string it will not be used. Instead the media/metadata will require a full functional URL

--- a/src/app/account/orders/orders.component.spec.ts
+++ b/src/app/account/orders/orders.component.spec.ts
@@ -32,8 +32,12 @@ class StoreMock {
 
 class ConfigServiceMock {
   public config = {
-    basemaps: [vi.fn()],
-    initialExtent: [0, 0, 1, 1],
+    map: {
+      basemaps: [vi.fn()],
+      projection: {
+        initialExtent: [0, 0, 1, 1],
+      }
+    },
     pageformats: [{ name: "", height: 1, width: 1 }],
   }
 }

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -73,11 +73,10 @@ export class AppComponent implements OnDestroy {
           });
     });
 
-    combineLatest([routerNavEnd$, this.store.select(selectCartTotal), this.store.select(selectMapState)])
+    combineLatest([routerNavEnd$, this.store.select(selectCartTotal)])
       .subscribe((pair) => {
         const navEnd = pair[0];
         const numberOfItemInTheCart = pair[1];
-        const mapState = pair[2];
         if (navEnd instanceof NavigationEnd) {
           if (navEnd.url.indexOf('orders') > -1) {
             this.subTitle = $localize`Mes commandes`;

--- a/src/app/helpers/geoHelper.ts
+++ b/src/app/helpers/geoHelper.ts
@@ -30,7 +30,7 @@ export const formatArea = (area: number): string => {
 
 export async function generateMiniMap(configService: ConfigService, mapService: MapService) {
   mapService.initialize();
-  const EPSG = configService.config?.epsg || 'EPSG:2056';
+  const EPSG = configService.config?.map.projection.epsg || 'EPSG:2056';
   if (!mapService.FirstBaseMapLayer) {
     proj4.defs(EPSG,
       '+proj=somerc +lat_0=46.95240555555556 +lon_0=7.439583333333333'
@@ -56,7 +56,7 @@ export async function generateMiniMap(configService: ConfigService, mapService: 
 
   const projection = new Projection({
     code: EPSG,
-    extent: configService.config?.initialExtent || DEFAULT_EXTENT,
+    extent: configService.config?.map.projection.initialExtent || DEFAULT_EXTENT,
   });
   const view = new View({
     projection,
@@ -64,7 +64,7 @@ export async function generateMiniMap(configService: ConfigService, mapService: 
     zoom: 4,
   });
 
-  const baseMapConfig = configService.config?.basemaps[0];
+  const baseMapConfig = configService.config?.map.basemaps[0];
 
   let layers;
   if (baseMapConfig) {

--- a/src/app/models/IConfig.ts
+++ b/src/app/models/IConfig.ts
@@ -1,4 +1,5 @@
 import { OpenIdConfiguration } from "angular-auth-oidc-client";
+import { Extent } from "ol/extent";
 
 export interface IBasemap {
   id: string;
@@ -17,6 +18,17 @@ export interface ISearchConfig {
   providerType: string;
 }
 
+export interface IMapConfig {
+  projection: {
+      epsg: string;
+      initialExtent: Extent;
+  }
+  defaultCenter: number[];
+  basemaps: IBasemap[];
+  constraints: Extent;
+  resolutions: number[];
+}
+
 // TODO it look like thie interface is never used -> remove it or use it!
 export interface IConfig {
   apiUrl: string;
@@ -28,11 +40,7 @@ export interface IConfig {
     phone: { label: string; number: string };
     email: string;
   };
-  basemaps: IBasemap[];
-  initialCenter: number[];
-  initialExtent: number[];
-  resolutions: number[];
-  epsg: string;
+  map: IMapConfig;
   pageformats: IPageFormat[];
   oidcConfig: OpenIdConfiguration;
   localAuthEnabled: boolean;

--- a/src/app/services/map.service.spec.ts
+++ b/src/app/services/map.service.spec.ts
@@ -22,7 +22,11 @@ class StoreMock {
 
 class ConfigServiceMock {
   public config = {
-    initialExtent: [0, 0, 1, 1],
+    map: {
+      projection: {
+        initialExtent: [0, 0, 1, 1],
+      }
+    },
     pageformats: [{ name: "", height: 1, width: 1 }],
   }
 }

--- a/src/app/store/map/map.reducer.ts
+++ b/src/app/store/map/map.reducer.ts
@@ -1,14 +1,17 @@
 import { createReducer, on } from '@ngrx/store';
+import { Extent } from 'ol/extent';
 
 import { saveState } from './map.action';
 
+
+
 export interface MapState {
-  bounds: [number, number, number, number];
+  bounds: Extent;
 }
 
 const initialState: MapState = {
   // Bounds in EPSG:2056
-  bounds: [2699266.122561534,1140974.9002843325,2832866.122561534,1234074.9002843325]
+  bounds: [2699266.122561534,1140974.9002843325,2832866.122561534,1234074.9002843325] as Extent
 };
 
 export const reducer = createReducer(

--- a/src/app/welcome/map/manualentry/manualentry.component.spec.ts
+++ b/src/app/welcome/map/manualentry/manualentry.component.spec.ts
@@ -62,7 +62,7 @@ describe('ManualentryComponent', () => {
   function expectError(component: ManualentryComponent, error: string) {
     expect(component.form.invalid).toBe(true);
     for (const f of ["xmin", "ymin", "xmax", "ymax"]) {
-      expect(component.form.controls['xmin'].hasError(error)).toBe(true);
+      expect(component.form.controls[f].hasError(error)).toBe(true);
     }
   }
 

--- a/src/app/welcome/map/map.component.spec.ts
+++ b/src/app/welcome/map/map.component.spec.ts
@@ -31,7 +31,11 @@ class StoreMock {
 
 class ConfigServiceMock {
   public config = {
-    initialExtent: [0, 0, 1, 1],
+    map: {
+      projection: {
+        initialExtent: [0, 0, 1, 1],
+      }
+    },
     pageformats: [{ name: "", height: 1, width: 1 }],
   }
 }

--- a/src/app/welcome/map/map.component.ts
+++ b/src/app/welcome/map/map.component.ts
@@ -89,6 +89,10 @@ export class MapComponent implements OnInit {
     this.basemaps = this.mapService.Basemaps || [];
     this.manualEntryParams.pageFormats = this.mapService.PageFormats || [];
     this.manualEntryParams.selectedPageFormat = this.configService.config?.pageformats[0] as IPageFormat;
+    const constraints = this.configService.config?.map.constraints;
+    if (constraints) {
+        this.manualEntryParams.constraints = constraints ;
+    }
 
     if (this.searchCtrl) {
       this.searchCtrl.valueChanges

--- a/src/app/welcome/welcome.component.spec.ts
+++ b/src/app/welcome/welcome.component.spec.ts
@@ -49,7 +49,11 @@ class StoreMock {
 
 class ConfigServiceMock {
   public config = {
-    initialExtent: [0, 0, 1, 1],
+    map: {
+      projection: {
+        initialExtent: [0, 0, 1, 1],
+      }
+    },
     pageformats: [{ name: "", height: 1, width: 1 }],
   }
 }

--- a/src/assets/configs/config.json.tmpl
+++ b/src/assets/configs/config.json.tmpl
@@ -20,33 +20,35 @@
     },
     "email": "info@geogr.ch"
   },
-  "initialCenter": [
-    2765505.527577451, 1173931.8492200195
-  ],
-  "initialExtent": [
-    2419995.7488073637, 1030006.663199476, 2900009.727428728, 1350004.292478851
-  ],
-  "resolutions": [250, 100, 50, 20, 10, 5, 2.5, 2, 1.5, 1, 0.5, 0.25],
-  "epsg": "EPSG:2056",
-  "basemaps": [
-    {
-      "id": "ch.swisstopo.pixelkarte-grau",
-      "label": "Landeskarten (grau)",
-      "description": "Landeskarten (grau)",
-      "thumbUrl": "assets/images/planville.png",
-      "matrixSet": "2056",
-      "format": "jpeg",
-      "boundingBoxWGS84": [5.140242, 45.398181, 11.47757, 48.230651]
-    },{
-      "id": "ch.swisstopo.pixelkarte-grau",
-      "label": "Karte Grau",
-      "description": "Karte Grau",
-      "thumbUrl": "assets/images/cadastre.png",
-      "matrixSet": "2056",
-      "format": "jpeg",
-      "boundingBoxWGS84": [5.140242, 45.398181, 11.47757, 48.230651]
-    }
-  ],
+  "map": {
+    "constraints": [2400000, 1030000, 2900010, 1400000],
+    "resolutions": [250, 100, 50, 20, 10, 5, 2.5, 2, 1.5, 1, 0.5, 0.25],
+    "defaultCenter": [2765505.527577451, 1173931.8492200195],
+    "projection": {
+      "epsg": "EPSG:2056",
+      "initialExtent": [2419995.7488073637, 1030006.663199476, 2900009.727428728, 1350004.292478851]
+    },
+    "basemaps": [
+      {
+        "id": "ch.swisstopo.pixelkarte-grau",
+        "label": "Landeskarten (grau)",
+        "description": "Landeskarten (grau)",
+        "thumbUrl": "assets/images/planville.png",
+        "matrixSet": "2056",
+        "format": "jpeg",
+        "boundingBoxWGS84": [5.140242, 45.398181, 11.47757, 48.230651]
+      },
+      {
+        "id": "ch.swisstopo.pixelkarte-grau",
+        "label": "Karte Grau",
+        "description": "Karte Grau",
+        "thumbUrl": "assets/images/cadastre.png",
+        "matrixSet": "2056",
+        "format": "jpeg",
+        "boundingBoxWGS84": [5.140242, 45.398181, 11.47757, 48.230651]
+      }
+    ]
+  },
   "pageformats": [
     {
       "name": "A4",


### PR DESCRIPTION
Fixes #187 

1. It's possible to define strict bounds for the map. OpenLayers can handle overflow / bounds outside allowed area by itself.
2. Grouped all map-related configurations into one group.