### PR TITLE
fix(GSGGR-508): GeoShop: search for products does not work

### DIFF
--- a/src/app/welcome/catalog/catalog.component.html
+++ b/src/app/welcome/catalog/catalog.component.html
@@ -1,5 +1,5 @@
 <mat-form-field color="primary">
-  <input matInput  [formControl]="productFilter" i18n-placeholder="@@catalog_productSearch"
+  <input type="text" matInput  [formControl]="productFilter" i18n-placeholder="@@catalog_productSearch"
     placeholder="Rechercher un produit...">
   <div matSuffix class="flex-row">
     <button *ngIf="productFilter.value" mat-icon-button aria-label="Clear"
@@ -10,7 +10,7 @@
 </mat-form-field>
 
 <div class="list-container">
-  @for (product of filteredProducts | async; track product.id) {
+  @for (product of filteredProducts | async; track trackByIdx(product.id)) {
   <div [style.height]="catalogItemHeight + 'px'" class="list-group-item">
     <img class="item-logo rounded-image" alt="Logo du produit" aria-label="Logo du produit"
       src="{{mediaUrl}}{{product.thumbnail_link}}">

--- a/src/app/welcome/catalog/catalog.component.html
+++ b/src/app/welcome/catalog/catalog.component.html
@@ -1,44 +1,36 @@
 <mat-form-field color="primary">
-  <input matInput [formControl]="catalogInputControl" i18n-placeholder="@@catalog_productSearch"
+  <input matInput  [formControl]="productFilter" i18n-placeholder="@@catalog_productSearch"
     placeholder="Rechercher un produit...">
   <div matSuffix class="flex-row">
-    <mat-spinner *ngIf="isSearchLoading" diameter="16" color="accent" style="margin-right: 10px"></mat-spinner>
-    <button *ngIf="catalogInputControl.value" mat-icon-button aria-label="Clear"
-      (click)="catalogInputControl.setValue('')">
+    <button *ngIf="productFilter.value" mat-icon-button aria-label="Clear"
+      (click)="productFilter.setValue('')">
       <mat-icon>close</mat-icon>
     </button>
   </div>
 </mat-form-field>
 
-<ng-container *ngIf="infinite|async as products">
-  <cdk-virtual-scroll-viewport class="list-container" [itemSize]="catalogItemHeight"
-    (scrolledIndexChange)="nextBatch($event, products.length-1)">
-
-    <div [style.height]="catalogItemHeight + 'px'"
-      *cdkVirtualFor="let product of products;let i = index; trackBy: trackByIdx" class="list-group-item">
-
-      <img class="item-logo rounded-image" alt="Logo du produit" aria-label="Logo du produit"
-        src="{{mediaUrl}}{{product.thumbnail_link}}">
-      <div class="item-label text-ellipsis-2">{{product.label}}</div>
-      <div *ngIf="product.metadata_summary.geoportal_link.length > 0" class="item-links text-ellipsis-2">
-        <a mat-icon-button color="primary" href="{{product.metadata_summary.geoportal_link}}" i18n>
-          Voir sur le géoportail<mat-icon class="icon-sm">open_in_new</mat-icon>
-        </a>
-      </div>
-
-
-      <button class="item-help" i18n-matTooltip matTooltip="Voir les meta données" i18n-aria-label
-        aria-label="Voir les meta données" [disabled]="!product.metadata" color="primary" mat-button
-        (click)="openMetadata(product)">
-        <mat-icon>description</mat-icon>
-      </button>
-
-      <button class="item-cart" color="primary" mat-button i18n-matTooltip matTooltip="Ajouter au panier"
-        i18n-aria-label aria-label="Ajouter au panier" (click)="addToCart(product)">
-        <mat-icon>add_shopping_cart</mat-icon>
-      </button>
-
+<div class="list-container">
+  @for (product of filteredProducts | async; track product.id) {
+  <div [style.height]="catalogItemHeight + 'px'" class="list-group-item">
+    <img class="item-logo rounded-image" alt="Logo du produit" aria-label="Logo du produit"
+      src="{{mediaUrl}}{{product.thumbnail_link}}">
+    <div class="item-label text-ellipsis-2">{{product.label}}</div>
+    <div *ngIf="product.metadataSummary?.geoportal_link.length > 0" class="item-links text-ellipsis-2">
+      <a mat-icon-button color="primary" href="{{product.metadataSummary?.geoportal_link}}" i18n>
+        Voir sur le géoportail<mat-icon class="icon-sm">open_in_new</mat-icon>
+      </a>
     </div>
 
-  </cdk-virtual-scroll-viewport>
-</ng-container>
+    <button class="item-help" i18n-matTooltip matTooltip="Voir les meta données" i18n-aria-label
+      aria-label="Voir les meta données" [disabled]="!product.metadata" color="primary" mat-button
+      (click)="openMetadata(product)">
+      <mat-icon>description</mat-icon>
+    </button>
+
+    <button class="item-cart" color="primary" mat-button i18n-matTooltip matTooltip="Ajouter au panier" i18n-aria-label
+      aria-label="Ajouter au panier" (click)="addToCart(product)">
+      <mat-icon>add_shopping_cart</mat-icon>
+    </button>
+  </div>
+  }
+</div>

--- a/src/app/welcome/catalog/catalog.component.spec.ts
+++ b/src/app/welcome/catalog/catalog.component.spec.ts
@@ -2,18 +2,23 @@ import { AppState } from '@app/store';
 
 import { provideHttpClient } from '@angular/common/http';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { ReactiveFormsModule } from '@angular/forms';
 import { MatButtonModule } from '@angular/material/button';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatIconModule } from '@angular/material/icon';
 import { MatInputModule } from '@angular/material/input';
-import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { Store } from '@ngrx/store';
 import { of } from 'rxjs';
 import { vi } from 'vitest';
 
 import { CatalogComponent } from './catalog.component';
+import { ApiService } from '@app/services/api.service';
+import { IApiResponse } from '@app/models/IApi';
+import { IProduct } from '@app/models/IProduct';
+import { CommonModule } from '@angular/common';
+import { MatDialogModule } from '@angular/material/dialog';
+import { By } from '@angular/platform-browser';
 
 
 class StoreMock {
@@ -21,34 +26,41 @@ class StoreMock {
   dispatch = vi.fn();
 }
 
+class MockApiService {
+  apiUrl = "";
+  getProducts = () => {
+    return of({
+      count: 0, next: "", previous: "",
+      results: [
+        { id: 1, label: "Product 1" },
+        { id: 2, label: "Product 2" },
+        { id: 3, label: "PRODUCT 3" },
+        { id: 4, label: "not a PROducT" }
+      ]
+    } as IApiResponse<IProduct>);
+  }
+}
+
 describe('CatalogComponent', () => {
   let component: CatalogComponent;
   let fixture: ComponentFixture<CatalogComponent>;
 
-  beforeEach(() => {
-    TestBed.configureTestingModule({
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
       imports: [
-        ReactiveFormsModule,
-        MatFormFieldModule,
-        MatIconModule,
-        MatInputModule,
-        MatButtonModule,
-        NoopAnimationsModule,
-        CatalogComponent,
+        MatFormFieldModule, ReactiveFormsModule,
+        CommonModule, MatInputModule, MatIconModule, MatButtonModule, MatDialogModule
       ],
       providers: [
+        { provide: ApiService, useClass: MockApiService },
         { provide: Store<AppState>, useClass: StoreMock },
         provideHttpClient(),
         provideHttpClientTesting(),
       ]
-    })
-      .compileComponents();
-  });
+    }).compileComponents();
 
-  beforeEach(() => {
     fixture = TestBed.createComponent(CatalogComponent);
     component = fixture.componentInstance;
-    fixture.detectChanges();
   });
 
   it('should create', () => {

--- a/src/app/welcome/catalog/catalog.component.ts
+++ b/src/app/welcome/catalog/catalog.component.ts
@@ -7,45 +7,40 @@ import { AppState, selectOrder } from '@app/store';
 import { updateOrder } from '@app/store/cart/cart.action';
 import { DialogMetadataComponent } from '@app/welcome/catalog/dialog-metadata/dialog-metadata.component';
 
-import { CdkVirtualScrollViewport, ScrollingModule } from '@angular/cdk/scrolling';
 import { CommonModule } from '@angular/common';
 import { Component, OnInit, ElementRef, ViewChild } from '@angular/core';
-import { ReactiveFormsModule, UntypedFormControl } from '@angular/forms';
+import { FormControl, ReactiveFormsModule, UntypedFormControl } from '@angular/forms';
 import { MatButtonModule } from '@angular/material/button';
 import { MatDialog, MatDialogModule } from '@angular/material/dialog';
 import { MatIconModule } from '@angular/material/icon';
 import { MatFormField, MatInputModule } from '@angular/material/input';
-import { MatProgressSpinner } from '@angular/material/progress-spinner';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { Store } from '@ngrx/store';
-import { BehaviorSubject, merge, Observable } from 'rxjs';
-import { debounceTime, map, mergeMap, scan, switchMap, tap, throttleTime } from 'rxjs/operators';
 
-
+import { catchError, filter, map, switchMap, withLatestFrom } from 'rxjs/operators';
+import { BehaviorSubject, combineLatest, merge, of, Subject } from 'rxjs';
 
 @Component({
   selector: 'gs2-catalog',
   templateUrl: './catalog.component.html',
   styleUrls: ['./catalog.component.scss'],
   imports: [
-    MatFormField, ReactiveFormsModule, MatProgressSpinner, CdkVirtualScrollViewport,
-    ScrollingModule, CommonModule, MatInputModule, MatIconModule, MatButtonModule, MatDialogModule
+    MatFormField, ReactiveFormsModule,
+    CommonModule, MatInputModule, MatIconModule, MatButtonModule, MatDialogModule
   ],
 })
-export class CatalogComponent implements OnInit {
-
-  // Infinity scrolling
-  @ViewChild(CdkVirtualScrollViewport) viewport: CdkVirtualScrollViewport;
-  batch = 20;
-  offset = new BehaviorSubject<number | null>(null);
-  infinite: Observable<IProduct[] | unknown[]>;
-  total = 0;
+export class CatalogComponent {
   stepToLoadData = 0;
   readonly catalogItemHeight = 64;
   isSearchLoading = false;
 
   // Filtering
-  catalogInputControl = new UntypedFormControl('');
+  productFilter = new FormControl<string>('');
+  allProducts = new BehaviorSubject<IProduct[]>([]) ;
+
+  filteredProducts = combineLatest([this.allProducts, merge(of(""), this.productFilter.valueChanges)]).pipe(
+    map(([products, query]) => products.filter((p) => query == null || query.length < 3 || p.label.indexOf(query) != -1))
+  );
 
   mediaUrl: string | undefined;
   order: IOrder;
@@ -53,60 +48,12 @@ export class CatalogComponent implements OnInit {
   constructor(private apiService: ApiService,
     public dialog: MatDialog,
     private store: Store<AppState>,
-    private elRef: ElementRef,
     private snackBar: MatSnackBar,
     private configService: ConfigService) {
 
     this.store.select(selectOrder).subscribe(x => this.order = x);
-
-    const batchMap = this.offset.pipe(
-      throttleTime(500),
-      mergeMap((n: number) => this.getBatch(n)),
-      scan((acc, batch) => {
-        return { ...acc, ...batch };
-      }, {})
-    );
-
     this.mediaUrl = this.configService.config?.mediaUrl ? `${this.configService.config.mediaUrl}/` : '';
-
-    this.infinite = merge(
-      batchMap.pipe(map(v => Object.values(v))),
-      this.catalogInputControl.valueChanges.pipe(
-        debounceTime(500),
-        switchMap(inputText => {
-          this.isSearchLoading = true;
-
-          if (!inputText || inputText.length < 2) {
-            return this.apiService.getProducts(0, this.batch)
-              .pipe(
-                map((response) => {
-                  this.isSearchLoading = false;
-                  this.total = response ? response.count : 0;
-                  return response ? response.results : [];
-                })
-              );
-          }
-
-          return this.apiService.find<IProduct>(inputText, 'product').pipe(
-            map(response => {
-              this.isSearchLoading = false;
-              this.total = response ? response.count : 0;
-              return response ? response.results : [];
-            })
-          );
-        })
-      )
-    );
-  }
-
-  ngOnInit(): void {
-    const firstElement = this.elRef.nativeElement.children[0].clientHeight;
-    const heightAvailable = this.elRef.nativeElement.clientHeight - firstElement - 10;
-
-    const numberOfRowPossible = Math.trunc(heightAvailable / this.catalogItemHeight);
-    const half = Math.trunc(numberOfRowPossible / 2);
-    this.stepToLoadData = numberOfRowPossible - half;
-    this.batch = numberOfRowPossible + half;
+    this.apiService.getProducts().pipe(map((p) => p?.results ?? [])).subscribe(this.allProducts);
   }
 
   addToCart(product: IProduct) {
@@ -121,33 +68,6 @@ export class CatalogComponent implements OnInit {
       this.snackBar.open($localize`Le produit est déjà dans le panier`, $localize`Fermer`, { duration: 3000 });
     }
     this.store.dispatch(updateOrder({ order }));
-  }
-
-  getBatch(offset: number) {
-    return this.apiService.getProducts(offset, this.batch)
-      .pipe(
-        tap(response => this.total = response ? response.count : 0),
-        map((response) => response ? response.results : []),
-        map(arr => {
-          return arr.reduce((acc, cur) => {
-            const id = cur.label;
-            return { ...acc, [id]: cur };
-          }, {});
-        })
-      );
-  }
-
-  nextBatch(e: number, offset: number) {
-    if (offset + 1 >= this.total) {
-      return;
-    }
-
-    const end = this.viewport.getRenderedRange().end;
-    const total = this.viewport.getDataLength();
-
-    if (end === total) {
-      this.offset.next(offset);
-    }
   }
 
   trackByIdx(i: number) {

--- a/src/app/welcome/welcome.component.spec.ts
+++ b/src/app/welcome/welcome.component.spec.ts
@@ -38,6 +38,7 @@ import { ManualentryComponent } from './map/manualentry/manualentry.component';
 import { MapComponent } from './map/map.component';
 import { ValidateComponent } from './validate/validate.component';
 import { WelcomeComponent } from './welcome.component';
+import { ApiService } from '@app/services/api.service';
 
 
 
@@ -56,6 +57,11 @@ class ConfigServiceMock {
     },
     pageformats: [{ name: "", height: 1, width: 1 }],
   }
+}
+
+class MockApiService {
+  apiUrl = "";
+  getProducts = vi.fn().mockImplementation(() => of(null));
 }
 
 describe('WelcomeComponent', () => {
@@ -99,6 +105,7 @@ describe('WelcomeComponent', () => {
         provideHttpClient(),
         provideHttpClientTesting(),
         { provide: ActivatedRoute, useValue: { queryParamMap: of() } },
+        { provide: ApiService, useClass: MockApiService },
         { provide: ConfigService, useClass: ConfigServiceMock },
         { provide: Store<AppState>, useClass: StoreMock }
       ]

--- a/src/locale/messages.de.xlf
+++ b/src/locale/messages.de.xlf
@@ -906,7 +906,7 @@
         <target>Meine Bestellungen</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/app.component.ts</context>
-          <context context-type="linenumber">83</context>
+          <context context-type="linenumber">82</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2835126772987299546" datatype="html">
@@ -914,7 +914,7 @@
         <target>Ihre Bestellung von <x id="PH" equiv-text="numberOfItemInTheCart"/> Produkten</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/app.component.ts</context>
-          <context context-type="linenumber">85</context>
+          <context context-type="linenumber">84</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5977257151487958132" datatype="html">
@@ -1482,12 +1482,24 @@
         <target> Auf dem Geoportal öffnen<x id="START_TAG_MAT_ICON" ctype="x-mat_icon" equiv-text="&lt;mat-icon class=&quot;icon-sm&quot;&gt;"/>open_in_new<x id="CLOSE_TAG_MAT_ICON" ctype="x-mat_icon" equiv-text="&lt;/mat-icon&gt;"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/welcome/catalog/catalog.component.html</context>
-          <context context-type="linenumber">25</context>
+          <context context-type="linenumber">20</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3967568504340829864" datatype="html">
         <source>Voir les meta données</source>
         <target>Metadaten anzeigen</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/welcome/catalog/catalog.component.html</context>
+          <context context-type="linenumber">24</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/welcome/catalog/catalog.component.html</context>
+          <context context-type="linenumber">25</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="6492937435856655320" datatype="html">
+        <source>Ajouter au panier</source>
+        <target>Zum Warenkorb hinzufügen</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/welcome/catalog/catalog.component.html</context>
           <context context-type="linenumber">30</context>
@@ -1497,24 +1509,12 @@
           <context context-type="linenumber">31</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="6492937435856655320" datatype="html">
-        <source>Ajouter au panier</source>
-        <target>Zum Warenkorb hinzufügen</target>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/welcome/catalog/catalog.component.html</context>
-          <context context-type="linenumber">36</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/welcome/catalog/catalog.component.html</context>
-          <context context-type="linenumber">37</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="5618137344171566342" datatype="html">
         <source>Le produit est déjà dans le panier</source>
         <target>Das Produkt befindet sich bereits im Warenkorb</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/welcome/catalog/catalog.component.ts</context>
-          <context context-type="linenumber">121</context>
+          <context context-type="linenumber">77</context>
         </context-group>
       </trans-unit>
       <trans-unit id="9059155436017318544" datatype="html">
@@ -1522,7 +1522,7 @@
         <target>Schliessen</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/welcome/catalog/catalog.component.ts</context>
-          <context context-type="linenumber">121</context>
+          <context context-type="linenumber">77</context>
         </context-group>
       </trans-unit>
       <trans-unit id="dialog.metadata" datatype="html">

--- a/src/locale/messages.en.xlf
+++ b/src/locale/messages.en.xlf
@@ -607,7 +607,7 @@
         <target>My orders</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/app.component.ts</context>
-          <context context-type="linenumber">83</context>
+          <context context-type="linenumber">82</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2835126772987299546" datatype="html">
@@ -615,7 +615,7 @@
         <target>Your order of <x id="PH" equiv-text="numberOfItemInTheCart"/> products</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/app.component.ts</context>
-          <context context-type="linenumber">85</context>
+          <context context-type="linenumber">84</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5977257151487958132" datatype="html">
@@ -1111,7 +1111,7 @@
         <target> View on the geoportal<x id="START_TAG_MAT_ICON" ctype="x-mat_icon" equiv-text="&lt;mat-icon class=&quot;icon-sm&quot;&gt;"/>open_in_new<x id="CLOSE_TAG_MAT_ICON" ctype="x-mat_icon" equiv-text="&lt;/mat-icon&gt;"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/welcome/catalog/catalog.component.html</context>
-          <context context-type="linenumber">25</context>
+          <context context-type="linenumber">20</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3967568504340829864" datatype="html">
@@ -1119,11 +1119,11 @@
         <target>View the metadata</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/welcome/catalog/catalog.component.html</context>
-          <context context-type="linenumber">30</context>
+          <context context-type="linenumber">24</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/welcome/catalog/catalog.component.html</context>
-          <context context-type="linenumber">31</context>
+          <context context-type="linenumber">25</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6492937435856655320" datatype="html">
@@ -1131,11 +1131,11 @@
         <target>Add to cart</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/welcome/catalog/catalog.component.html</context>
-          <context context-type="linenumber">36</context>
+          <context context-type="linenumber">30</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/welcome/catalog/catalog.component.html</context>
-          <context context-type="linenumber">37</context>
+          <context context-type="linenumber">31</context>
         </context-group>
       </trans-unit>
       <trans-unit id="dialog.metadata" datatype="html">
@@ -1711,7 +1711,7 @@
         <target state="translated">This product is already in your cart</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/welcome/catalog/catalog.component.ts</context>
-          <context context-type="linenumber">121</context>
+          <context context-type="linenumber">77</context>
         </context-group>
       </trans-unit>
       <trans-unit id="9059155436017318544" datatype="html">
@@ -1719,7 +1719,7 @@
         <target state="translated">Close</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/welcome/catalog/catalog.component.ts</context>
-          <context context-type="linenumber">121</context>
+          <context context-type="linenumber">77</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6696706704241708718" datatype="html">

--- a/src/locale/messages.xlf
+++ b/src/locale/messages.xlf
@@ -626,14 +626,14 @@
         <source>Mes commandes</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/app.component.ts</context>
-          <context context-type="linenumber">83</context>
+          <context context-type="linenumber">82</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2835126772987299546" datatype="html">
         <source>Votre commande de <x id="PH" equiv-text="numberOfItemInTheCart"/> produits</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/app.component.ts</context>
-          <context context-type="linenumber">85</context>
+          <context context-type="linenumber">84</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5977257151487958132" datatype="html">
@@ -1328,11 +1328,22 @@
         <source> Voir sur le géoportail<x id="START_TAG_MAT_ICON" ctype="x-mat_icon" equiv-text="&lt;mat-icon class=&quot;icon-sm&quot;&gt;"/>open_in_new<x id="CLOSE_TAG_MAT_ICON" ctype="x-mat_icon" equiv-text="&lt;/mat-icon&gt;"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/welcome/catalog/catalog.component.html</context>
-          <context context-type="linenumber">25</context>
+          <context context-type="linenumber">20</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3967568504340829864" datatype="html">
         <source>Voir les meta données</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/welcome/catalog/catalog.component.html</context>
+          <context context-type="linenumber">24</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/welcome/catalog/catalog.component.html</context>
+          <context context-type="linenumber">25</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="6492937435856655320" datatype="html">
+        <source>Ajouter au panier</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/welcome/catalog/catalog.component.html</context>
           <context context-type="linenumber">30</context>
@@ -1342,29 +1353,18 @@
           <context context-type="linenumber">31</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="6492937435856655320" datatype="html">
-        <source>Ajouter au panier</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/welcome/catalog/catalog.component.html</context>
-          <context context-type="linenumber">36</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/welcome/catalog/catalog.component.html</context>
-          <context context-type="linenumber">37</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="5618137344171566342" datatype="html">
         <source>Le produit est déjà dans le panier</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/welcome/catalog/catalog.component.ts</context>
-          <context context-type="linenumber">121</context>
+          <context context-type="linenumber">77</context>
         </context-group>
       </trans-unit>
       <trans-unit id="9059155436017318544" datatype="html">
         <source>Fermer</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/welcome/catalog/catalog.component.ts</context>
-          <context context-type="linenumber">121</context>
+          <context context-type="linenumber">77</context>
         </context-group>
       </trans-unit>
       <trans-unit id="dialog.metadata" datatype="html">
@@ -1653,7 +1653,6 @@
       </trans-unit>
       <trans-unit id="3297562179987742303" datatype="html">
         <source> La valeur doit être comprise entre <x id="INTERPOLATION" equiv-text="{{data.constraints[0]}}"/> et <x id="INTERPOLATION_1" equiv-text="{{data.constraints[2]}}"/> </source>
-        <target> Value must be between <x id="INTERPOLATION" equiv-text="{{data.constraints[0]}}"/> and <x id="INTERPOLATION_1" equiv-text="{{data.constraints[2]}}"/> </target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/welcome/map/manualentry/manualentry.component.html</context>
           <context context-type="linenumber">35</context>


### PR DESCRIPTION
Fixed by removing an infinite scroll feature:
1. Products are loaded in one big chunk, without pagination.
2. Filtering happens locally.

While first step might seem questionable, there are not more than 200 products and loading and rendering them all is fine and the memory overhead is insignificant (~2 MB according to Firefox profiler).