### PR TITLE
feat(GSGGR-530): Add version information, make it visible to the user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,9 @@ FROM node:22.6.0-slim AS builder
 
 WORKDIR /usr/app
 
+ARG VERSION
+ENV VERSION=$VERSION
+
 COPY package*.json ./.
 RUN npm ci  --legacy-peer-deps
 

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
+    "prebuild": "echo export const version=\\\"${VERSION:-master}\\\"\\; > src/environments/version.ts",
     "build": "ng build",
     "test": "vitest",
     "stylelint": "stylelint '**/*.scss'",

--- a/src/app/components/help-overlay/help-overlay.component.html
+++ b/src/app/components/help-overlay/help-overlay.component.html
@@ -1,3 +1,8 @@
+<div class="version" mat-menu-item disabled>
+    <span>Geoshop {{versionInfo}}</span>
+</div>
+<mat-divider></mat-divider>
+
 <!-- TODO links are pointing to NE speciffic locations-->
 <a mat-menu-item href="https://youtu.be/KIkISZdYSU0" target="_blank">
   <mat-icon>support</mat-icon>

--- a/src/app/components/help-overlay/help-overlay.component.scss
+++ b/src/app/components/help-overlay/help-overlay.component.scss
@@ -1,0 +1,5 @@
+.version {
+  font-weight: 600;
+  opacity: 0.8;          /* dimmer than normal items */
+  cursor: default;
+}

--- a/src/app/components/help-overlay/help-overlay.component.ts
+++ b/src/app/components/help-overlay/help-overlay.component.ts
@@ -1,3 +1,5 @@
+import { environment } from '@app/../environments/environment';
+import { version } from '@app/../environments/version';
 import { ConfigService } from '@app/services/config.service';
 
 import { CommonModule } from '@angular/common';
@@ -26,6 +28,7 @@ export class HelpOverlayComponent {
   phoneLabel: string;
   phoneNumber: string;
   email: string;
+  versionInfo = `${version}-${environment.production ? "prod" : "test"}`;
 
   constructor(configService: ConfigService) {
     this.phoneLabel = configService.config?.contact.phone.label || '';

--- a/src/app/components/help-overlay/help-overlay.component.ts
+++ b/src/app/components/help-overlay/help-overlay.component.ts
@@ -28,7 +28,7 @@ export class HelpOverlayComponent {
   phoneLabel: string;
   phoneNumber: string;
   email: string;
-  versionInfo = `${version}-${environment.production ? "prod" : "test"}`;
+  versionInfo = `${version}-${environment.name}`;
 
   constructor(configService: ConfigService) {
     this.phoneLabel = configService.config?.contact.phone.label || '';

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,3 +1,4 @@
 export const environment = {
+  name: "prod",
   production: true
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -1,3 +1,4 @@
 export const environment = {
+  name: "test",
   production: false
 };


### PR DESCRIPTION
Using the same version as used to tag the docker image. So, "1.0.8-prod" means that the page belongs to the camptocamp/geoshop-front:1.0.8 image.

Docker image, built from branch
<img width="300" alt="tag-branch" src="https://github.com/user-attachments/assets/a237e266-f433-4c31-9151-f9ca263f960a" />

Docker image, production build:
<img width="300" alt="tag-prod" src="https://github.com/user-attachments/assets/96160aa9-f5b6-453c-b828-892ccc466c8f" />

Local run, from master branch
<img width="300"  alt="no_version" src="https://github.com/user-attachments/assets/f8a82515-bfdf-4e6b-b19b-48d13f05285d" />

Local run, with the version information 
<img width="300" alt="envvar_version" src="https://github.com/user-attachments/assets/eb69b572-9b1c-41e3-ac46-f18cd2254d17" />
