### PR TITLE
feat(GSGGR-539):  Fix infinite redirects when logging with Zitadel

### DIFF
--- a/src/app/interceptors/errorInterceptor.ts
+++ b/src/app/interceptors/errorInterceptor.ts
@@ -46,7 +46,9 @@ export const interceptor = (req: HttpRequest<unknown>, next: HttpHandlerFn): Obs
     catchError(response => {
       if (response instanceof HttpErrorResponse) {
         if (response.status === 401) {
-          store.dispatch(fromAuth.logout());
+          store.dispatch(fromAuth.loginFailure({
+            error: {detail: 'Unauthorized'}, message: 'Unauthorized', name: 'Unauthorized', status: 401,
+          }));
           router.navigate(['/auth/login']);
         } else {
           let message = "";

--- a/src/app/store/auth/auth.action.ts
+++ b/src/app/store/auth/auth.action.ts
@@ -7,7 +7,7 @@ import { LoginResponse } from 'angular-auth-oidc-client';
 
 export const LOGIN = '[Auth] Login';
 export const OIDC_LOGIN = '[Auth] Oidc Login';
-export const OIDC_AUTO_LOGIN_FAILURE = '[Auth] Oidc Auto Login';
+export const OIDC_LOGIN_PENDING = '[Auth] Oidc login pending';
 export const REFRESH_TOKEN = '[Auth] Refresh token';
 export const REFRESH_TOKEN_SUCCESS = '[Auth] Refresh token success';
 export const REFRESH_TOKEN_FAILURE = '[Auth] Refresh token failure';

--- a/src/app/store/auth/auth.reducer.ts
+++ b/src/app/store/auth/auth.reducer.ts
@@ -6,26 +6,26 @@ import * as AuthActions from './auth.action';
 
 export interface AuthState {
   loggedIn: boolean;
-  autoLoginFailed: boolean;
+  loginFailed: boolean;
   user: Partial<IIdentity> | null;
 }
 
 const initialState: AuthState = {
   loggedIn: false,
-  autoLoginFailed: false,
+  loginFailed: false,
   user: null,
 };
 
 const authReducer = createReducer(
   initialState,
-  on(AuthActions.loginSuccess, (state, { identity }) => ({ ...state, loggedIn: true, user: identity })),
+  on(AuthActions.loginSuccess, (state, { identity }) => ({ ...state, loggedIn: true, loginFailed: false, user: identity })),
   on(AuthActions.refreshTokenSuccess, (state, { token }) => {
     const user = Object.assign({}, state.user);
     user.token = token;
-    return { ...state, loggedIn: true, user };
+    return { ...state, loggedIn: true, loginFailed: false, user };
   }),
-  on(AuthActions.refreshTokenFailure, (state) => ({ ...state, loggedIn: false, user: null })),
-  on(AuthActions.loginFailure, (state) => ({ ...state, loggedIn: false, user: null })),
+  on(AuthActions.refreshTokenFailure, (state) => ({ ...state, loggedIn: false, loginFailed: true, user: null })),
+  on(AuthActions.loginFailure, (state) => ({ ...state, loggedIn: false, loginFailed: true, user: null })),
   on(AuthActions.logout, state => ({ ...state, loggedIn: false, user: null }))
 );
 


### PR DESCRIPTION
Now keeping auth error state to avoid infinite redirects.
After a successful login, or manual logout the "failed auth" status resets.