### PR TITLE
fix(GSGGR-547): Add locale to the url properly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,9 +31,13 @@ push_ghcr: ## Push docker image to GHCR
 	docker push ghcr.io/camptocamp/geoshop-front:$(VERSION)
 	docker push ghcr.io/camptocamp/geoshop-front:$(DOCKER_TAG)
 
+.PHONY: test_npm
+test_npm: install
+	npm test -- --no-watch
+
 .PHONY: test
-test: install ## Run tests
-	npm test
+test: test_npm test_e2e
+	@echo "All tests passed."
 
 .PHONY: help
 help: ## Display this help

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -1,12 +1,3 @@
-
-# Extract default language from the headers
-#
-# map $http_accept_language $accept_language {
-#   ~*^de de;
-#   ~*^fr fr;
-#   ~*^en en;
-# }
-
 server {
     listen 8080;
     server_name localhost;
@@ -16,24 +7,13 @@ server {
     absolute_redirect off;
 
     # Temporarily setting German as default language
-    set $accept_language "de";
+    set $lang "de";
 
-    # Fallback to default language if no preference defined by browser
-    if ($accept_language ~ "^$") {
-      set $accept_language "de";
+    location ~ /de.* {
+      try_files $uri /$lang/index.html?$args;
     }
 
-    # Redirect "/" to Angular application in the preferred language of the browser
-    rewrite ^/$ /$accept_language permanent;
-
-    location ~ index.html {
-      add_header Cache-Control "no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0";
-      expires -1;
-    }
-
-    # Everything under the Angular application is always redirected to Angular in the
-    # correct language
-    location ~ ^/(fr|de|en) {
-      try_files $uri /$1/index.html?$args;
+    location / {
+      return 301 /$lang$uri;
     }
 }


### PR DESCRIPTION
Change the way redirect happens. Removed extra no-cache arguments to simplify the matching (it's should not be needed for the production build when Angular adds a checksum to the file).
