### PR TITLE
fis(GSGGR-570): Fixed logo path to use svg and not png

### DIFF
--- a/src/assets/configs/config.json.tmpl
+++ b/src/assets/configs/config.json.tmpl
@@ -94,7 +94,11 @@
   },
   "noBillingForFreeOrder": ${NO_BILLING_FOR_FREE_ORDER},
   "appLogo": {
-    "path": "assets/images/logo.png",
+    "path": "assets/images/logo.svg",
+    "alt": "Company logo"
+  },
+  "appLogo1": {
+    "path": "assets/images/Logo_3-sprachig_4-farbig.svg",
     "alt": "Company logo"
   }
 }


### PR DESCRIPTION
Logo was not loaded because of the incorrect file extension