### PR TITLE
feat(GSGGR-547): Use local storage instead of session storage

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -95,8 +95,8 @@ export class AppComponent implements OnDestroy {
       AppComponent.autoLoginFailed = true;
     }
     if (this.configService.config?.oidcConfig && !AppComponent.autoLoginFailed) {
-      const authSubscription = new Subscription()
-      combineLatest([this.oidcService.checkAuth(), this.store.select(getUser)]).subscribe(([loginResponse, user]) => {
+      let authSubscription = new Subscription();
+      authSubscription = combineLatest([this.oidcService.checkAuthIncludingServer(), this.store.select(getUser)]).subscribe(([loginResponse, user]) => {
         const loggedIn = !!(loginResponse?.isAuthenticated && user);
         // log and push the current login state so templates/reactive consumers update
         this.isLoggedInSubject.next(loggedIn);
@@ -114,7 +114,7 @@ export class AppComponent implements OnDestroy {
               }
             }, 120000);
           }
-        } else if (!AppComponent.autoLoginFailed) {
+        } else if (!loginResponse.isAuthenticated) {
           this.oidcService.authorize(undefined, { customParams: { prompt: 'none' } });
         }
         authSubscription.unsubscribe();

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -3,6 +3,7 @@ import { routes } from '@app/app.routes';
 import { interceptor as authInterceptor } from '@app/interceptors/authInterceptor';
 import { interceptor as errorInterceptor } from '@app/interceptors/errorInterceptor';
 import { ConfigService } from '@app/services/config.service';
+import { OIDCStorageService } from '@app/services/oidc-storage.service';
 import * as store from '@app/store';
 import { AuthEffects } from '@app/store/auth/auth.effects';
 import { CartEffects } from '@app/store/cart/cart.effects';
@@ -13,7 +14,7 @@ import { provideAnimations } from '@angular/platform-browser/animations';
 import { provideRouter } from '@angular/router';
 import { provideEffects } from '@ngrx/effects';
 import { provideStore } from '@ngrx/store';
-import { provideAuth, StsConfigLoader, StsConfigStaticLoader } from 'angular-auth-oidc-client';
+import { AbstractSecurityStorage, provideAuth, StsConfigLoader, StsConfigStaticLoader } from 'angular-auth-oidc-client';
 
 
 
@@ -40,6 +41,7 @@ export const appConfig: ApplicationConfig = {
         deps: [ConfigService],
       },
     }),
+    { provide: AbstractSecurityStorage, useClass: OIDCStorageService },
     provideEffects(AuthEffects, CartEffects),
     provideStore(store.reducers, { metaReducers: store.metaReducers }),
     provideAppInitializer(() => inject(ConfigService).load())

--- a/src/app/services/oidc-storage.service.ts
+++ b/src/app/services/oidc-storage.service.ts
@@ -1,0 +1,24 @@
+import { Injectable } from '@angular/core';
+import { AbstractSecurityStorage } from 'angular-auth-oidc-client';
+
+
+@Injectable({
+  providedIn: 'root'
+})
+export class OIDCStorageService implements AbstractSecurityStorage {
+  read(key: string): string | null {
+    return localStorage.getItem(key);
+  }
+
+  write(key: string, value: string): void {
+    localStorage.setItem(key, value);
+  }
+
+  remove(key: string): void {
+    localStorage.removeItem(key);
+  }
+
+  clear(): void {
+    localStorage.clear();
+  }
+}


### PR DESCRIPTION
OIDC uses session storage by default and that can cause problems because different instances of geoshop-front could not interact with each other (e.g. when user authenticates in one tab and then tries to open a link from an email). While authentication flow still remains not very clean, that fix reduces number of user problems. 

Source: https://www.angular-auth-oidc-client.com/docs/documentation/custom-storage