### PR TITLE
Gsggr 667 mini map delay

### DIFF
--- a/src/app/account/orders/order/order.component.ts
+++ b/src/app/account/orders/order/order.component.ts
@@ -169,18 +169,18 @@ export class OrderComponent {
     });
   }
 
-  displayMiniMap() {
+  async displayMiniMap() {
     if (this.selectedOrder) {
-      displayMiniMap(this.selectedOrder, [this.minimap], [this.vectorSource], 0);
+      await displayMiniMap(this.selectedOrder, [this.minimap], [this.vectorSource], 0);
       return;
     }
 
-    this.apiOrderService.getOrder(this.order.url).subscribe((loadedOrder) => {
+    this.apiOrderService.getOrder(this.order.url).subscribe(async (loadedOrder) => {
       if (loadedOrder) {
         this.selectedOrder = new Order(loadedOrder);
         this.order.statusAsReadableIconText = this.selectedOrder.statusAsReadableIconText;
         this.generateOrderItemsElements(this.selectedOrder);
-        displayMiniMap(this.selectedOrder, [this.minimap], [this.vectorSource], 0);
+        await displayMiniMap(this.selectedOrder, [this.minimap], [this.vectorSource], 0);
       }
     });
   }

--- a/src/app/helpers/geoHelper.ts
+++ b/src/app/helpers/geoHelper.ts
@@ -91,11 +91,12 @@ export async function generateMiniMap(configService: ConfigService, mapService: 
   return { minimap, vectorSource };
 }
 
-export function displayMiniMap(order: Order, miniMaps: Map[], vectorSources: VectorSource[], index: number) {
+export async function displayMiniMap(order: Order, miniMaps: Map[], vectorSources: VectorSource[], index: number) {
   if (!order || !order.geom) {
     return;
   }
   const target = `mini-map-${order.id}`;
+  await waitForElementToDisplay(`#${target}`, 100, 5000);
   miniMaps[index].setTarget(target);
 
   const feature = new Feature();
@@ -113,4 +114,15 @@ export function displayMiniMap(order: Order, miniMaps: Map[], vectorSources: Vec
   miniMaps[index].getView().fit(order.geom, {
     padding: [50, 50, 50, 50]
   });
+}
+
+async function waitForElementToDisplay(selector: string, checkFrequencyInMs: number, timeoutInMs: number): Promise<boolean> {
+  const startTimeInMs = Date.now();
+  while (Date.now() - startTimeInMs < timeoutInMs) {
+    if (document.querySelector(selector) != null) {
+      return true;
+    }
+    await new Promise(resolve => setTimeout(resolve, checkFrequencyInMs));
+  }
+  return false;
 }

--- a/src/app/welcome/download/download.component.ts
+++ b/src/app/welcome/download/download.component.ts
@@ -64,10 +64,10 @@ export class DownloadComponent implements OnInit, OnDestroy {
       .subscribe(order => {
         if (order) {
           this.order = order;
-          generateMiniMap(this.configService, this.mapService).then(result => {
+          generateMiniMap(this.configService, this.mapService).then(async result => {
             this.minimap = result.minimap;
             this.vectorSource = result.vectorSource;
-            displayMiniMap(this.order, [this.minimap], [this.vectorSource], 0);
+            await displayMiniMap(this.order, [this.minimap], [this.vectorSource], 0);
           });
         }
       });

--- a/src/app/welcome/validate/validate.component.spec.ts
+++ b/src/app/welcome/validate/validate.component.spec.ts
@@ -114,7 +114,7 @@ describe('ValidateComponent', () => {
     vi.mock('@app/helpers/geoHelper', () => {
       return {
         generateMiniMap: async () => ({ minimap: null, vectorSource: null }),
-        displayMiniMap: () => ({})
+        displayMiniMap: async () => ({})
       };
     });
     items.next(fakeItem);

--- a/src/app/welcome/validate/validate.component.ts
+++ b/src/app/welcome/validate/validate.component.ts
@@ -68,7 +68,9 @@ export class ValidateComponent implements OnInit, OnDestroy {
         // TODO: improve this sync part with proper Angular logics (await for render)
         // angular experts needed ;-)
         // set timeout is a workaround which fixes the race condition.
-        setTimeout(() => displayMiniMap(order, [result.minimap], [result.vectorSource], 0), 50);
+        // setTimeout(() => displayMiniMap(order, [result.minimap], [result.vectorSource], 0), 50);
+        // 50ms is too short, do active wait for element
+        waitForElementToDisplay(`#mini-map-${order.id}`, () => displayMiniMap(order, [result.minimap], [result.vectorSource], 0), 100, 5000);
       });
     });
   }
@@ -86,4 +88,21 @@ export class ValidateComponent implements OnInit, OnDestroy {
       });
     });
   }
+}
+
+function waitForElementToDisplay(selector: string, callback: () => void, checkFrequencyInMs: number, timeoutInMs: number) {
+  const startTimeInMs = Date.now();
+  (function loopSearch() {
+    if (document.querySelector(selector) != null) {
+      callback();
+      return;
+    }
+    else {
+      setTimeout(function () {
+        if (timeoutInMs && Date.now() - startTimeInMs > timeoutInMs)
+          return;
+        loopSearch();
+      }, checkFrequencyInMs);
+    }
+  })();
 }

--- a/src/app/welcome/validate/validate.component.ts
+++ b/src/app/welcome/validate/validate.component.ts
@@ -62,7 +62,7 @@ export class ValidateComponent implements OnInit, OnDestroy {
       map(data => data.order),
       filter(order => !!order),
     ).subscribe(order => {
-      generateMiniMap(this.configService, this.mapService).then(result => {
+      generateMiniMap(this.configService, this.mapService).then(async result => {
         // a delay is needed so that the DOM has finished rendering and the target of
         // type `mini-map-${order.id}` exists
         // TODO: improve this sync part with proper Angular logics (await for render)
@@ -70,7 +70,8 @@ export class ValidateComponent implements OnInit, OnDestroy {
         // set timeout is a workaround which fixes the race condition.
         // setTimeout(() => displayMiniMap(order, [result.minimap], [result.vectorSource], 0), 50);
         // 50ms is too short, do active wait for element
-        waitForElementToDisplay(`#mini-map-${order.id}`, () => displayMiniMap(order, [result.minimap], [result.vectorSource], 0), 100, 5000);
+        // waitForElementToDisplay(`#mini-map-${order.id}`, () => displayMiniMap(order, [result.minimap], [result.vectorSource], 0), 100, 5000);
+        await displayMiniMap(order, [result.minimap], [result.vectorSource], 0)
       });
     });
   }
@@ -90,19 +91,3 @@ export class ValidateComponent implements OnInit, OnDestroy {
   }
 }
 
-function waitForElementToDisplay(selector: string, callback: () => void, checkFrequencyInMs: number, timeoutInMs: number) {
-  const startTimeInMs = Date.now();
-  (function loopSearch() {
-    if (document.querySelector(selector) != null) {
-      callback();
-      return;
-    }
-    else {
-      setTimeout(function () {
-        if (timeoutInMs && Date.now() - startTimeInMs > timeoutInMs)
-          return;
-        loopSearch();
-      }, checkFrequencyInMs);
-    }
-  })();
-}


### PR DESCRIPTION
This PR fixes inconsistent behaviour where the mini map is not displayed systematically.

Fix is extended to order and download view to improve robustness.

Instead of a fixed delay of 50ms, there is now a polling check every 100ms for up to 5s in order to wait for the element to be rendered.