### PR TITLE
fix(GSGGR-673): correctly handle when there is only one order type

### DIFF
--- a/src/app/account/new-order/new-order.component.html
+++ b/src/app/account/new-order/new-order.component.html
@@ -10,7 +10,7 @@
       <button color="warn" mat-button (click)="resetForms()">
         {{ AppConstants.RESET }}
       </button>
-      <button color="primary" mat-raised-button matStepperNext (click)="createOrUpdateDraft()">
+      <button color="primary" mat-raised-button matStepperNext (click)="createOrUpdateDraft()" [disabled]="!orderFormGroup.valid">
         {{ AppConstants.NEXT }}
       </button>
     </div>
@@ -30,7 +30,8 @@
           {{ AppConstants.RESET }}
         </button>
         <button color="primary" mat-button matStepperPrevious>{{ AppConstants.PREVIOUS }}</button>
-        <button color="primary" mat-raised-button matStepperNext (click)="createOrUpdateDraft()">{{ AppConstants.NEXT }}
+        <button color="primary" mat-raised-button matStepperNext (click)="createOrUpdateDraft()" [disabled]="!contactFormGroup.valid">
+          {{ AppConstants.NEXT }}
         </button>
       </div>
   </mat-step>

--- a/src/app/account/new-order/new-order.component.ts
+++ b/src/app/account/new-order/new-order.component.ts
@@ -2,8 +2,10 @@ import {
   AddressChoice,
   ContactForm,
   createContactForm,
-  createOrderForm, createOrderItemForm,
-  OrderForm, OrderItemForm
+  createOrderForm,
+  createOrderItemForm,
+  OrderForm,
+  OrderItemForm
 } from "@app/account/new-order/order-form.model";
 import {
   ContactPricingStepComponent
@@ -12,13 +14,13 @@ import {DataFormatStepComponent} from "@app/account/new-order/steps/data-format-
 import {OrderTypeStepComponent} from "@app/account/new-order/steps/order-type-step/order-type-step.component";
 import * as Constants from '@app/constants';
 import {Contact, IContact} from '@app/models/IContact';
-import {IOrder, Order, IOrderItem} from '@app/models/IOrder';
+import {IOrder, IOrderItem, Order} from '@app/models/IOrder';
 import {IProduct} from '@app/models/IProduct';
 import {ApiOrderService} from '@app/services/api-order.service';
 import {ApiService} from '@app/services/api.service';
 import {ConfigService} from '@app/services/config.service';
 import {StoreService} from '@app/services/store.service';
-import {AppState, getUser, selectOrder, selectAllProduct} from '@app/store';
+import {AppState, getUser, selectAllProduct, selectOrder} from '@app/store';
 import * as fromCart from '@app/store/cart/cart.action';
 
 import {AsyncPipe, CommonModule} from '@angular/common';
@@ -178,6 +180,11 @@ export class NewOrderComponent implements OnInit {
       description: this.currentOrder.description
     });
     this.contactFormGroup.patchValue(this.invoiceContact ?? {});
+    if (this.orderFormGroup.get('orderType')?.value?.id !== 1) {
+      this.contactFormGroup.patchValue({
+        addressChoice: AddressChoice.OTHER_PERSON
+      });
+    }
 
     this.allAvailableFormats = new Set();
     const orderItemControls = this.orderItemFormGroup.controls.format;

--- a/src/app/account/new-order/new-order.component.ts
+++ b/src/app/account/new-order/new-order.component.ts
@@ -198,7 +198,7 @@ export class NewOrderComponent implements OnInit {
     this.currentOrder.invoice_reference = orderValues.invoice_reference;
     this.currentOrder.email_deliver = orderValues.emailDeliverChoice === '2' ? orderValues.emailDeliver : '';
     this.currentOrder.description = orderValues.description;
-    this.currentOrder.order_type = orderValues.orderType.name;
+    this.currentOrder.order_type = orderValues.orderType?.name ?? "";
 
     if (this.contactFormGroup.get('addressChoice')?.value === AddressChoice.OTHER_PERSON) {
       const contact: IContact = this.contactFormGroup.getRawValue();

--- a/src/app/account/new-order/order-form.model.ts
+++ b/src/app/account/new-order/order-form.model.ts
@@ -105,7 +105,7 @@ export const createContactForm = (): FormGroup<ContactForm> => {
     const ide_id = form.get('ide_id');
     const phone = form.get('phone');
 
-    if (addressChoice === '2') {
+    if (addressChoice === AddressChoice.OTHER_PERSON) {
       first_name?.setValidators([Validators.required]);
       last_name?.setValidators([Validators.required]);
       email?.setValidators(Validators.compose([Validators.required, Validators.pattern(EMAIL_REGEX)]));

--- a/src/app/account/new-order/order-form.model.ts
+++ b/src/app/account/new-order/order-form.model.ts
@@ -24,7 +24,7 @@ export const createOrderItemForm = (): FormGroup<OrderItemForm> => {
 
 // OrderForm
 export interface OrderForm {
-  orderType: FormControl<IOrderType>;
+  orderType: FormControl<IOrderType|null>;
   title: FormControl<string>;
   invoice_reference: FormControl<string>;
   emailDeliverChoice: FormControl<string>;
@@ -35,7 +35,7 @@ export interface OrderForm {
 export const createOrderForm = (): FormGroup<OrderForm> => {
   const fb = inject(NonNullableFormBuilder);
   const form = fb.group({
-    orderType: fb.control({id: 1, name: "private"}, Validators.required),
+    orderType: fb.control<IOrderType|null>({value: null, disabled: true}, Validators.required),
     title: fb.control("", Validators.compose([
       Validators.pattern(EXTRACT_FORBIDDEN_REGEX), Validators.required
     ])),
@@ -44,9 +44,9 @@ export const createOrderForm = (): FormGroup<OrderForm> => {
     emailDeliver: fb.control("", Validators.pattern(EMAIL_REGEX)),
     description: fb.control(""),
   });
-  form.get('orderType')?.valueChanges.subscribe(({id}) => {
+  form.get('orderType')?.valueChanges.subscribe((newType) => {
     const description = form.get('description');
-    if (id === 2) {
+    if (!newType || newType?.id === 2) {
       description?.setValidators([Validators.required]);
     } else {
       description?.clearValidators();

--- a/src/app/account/new-order/steps/contact-pricing-step/contact-pricing-step.component.html
+++ b/src/app/account/new-order/steps/contact-pricing-step/contact-pricing-step.component.html
@@ -8,7 +8,6 @@
   </mat-radio-group>
 
   <mat-label *ngIf="!isOrderTypePrivate && orderFormGroup.get('orderType')?.value" i18n>
-    <mat-error *ngIf="!contactFormGroup.touched">{{ AppConstants.REQUIRED }}</mat-error>
     Vous devez spécifier les informations de contact du tiers pour un mandat de type
     &quot;{{ getLocalizedTypeName(orderFormGroup.get('orderType')?.value) }}&quot;.
   </mat-label>

--- a/src/app/account/new-order/steps/contact-pricing-step/contact-pricing-step.component.html
+++ b/src/app/account/new-order/steps/contact-pricing-step/contact-pricing-step.component.html
@@ -7,8 +7,8 @@
     <mat-radio-button value="{{AppAddressChoice.OTHER_PERSON}}" i18n>La facturation est adressée à un mandant</mat-radio-button>
   </mat-radio-group>
 
-
   <mat-label *ngIf="!isOrderTypePrivate && orderFormGroup.get('orderType')?.value" i18n>
+    <mat-error *ngIf="!contactFormGroup.touched">{{ AppConstants.REQUIRED }}</mat-error>
     Vous devez spécifier les informations de contact du tiers pour un mandat de type
     &quot;{{ getLocalizedTypeName(orderFormGroup.get('orderType')?.value) }}&quot;.
   </mat-label>
@@ -53,7 +53,6 @@
         </button>
       </div>
     </div>
-
     <div class="customer_data" style="overflow: auto" *ngIf="isCustomerSelected">
       <!-- Contact info -->
       <mat-form-field color="primary">

--- a/src/app/account/new-order/steps/contact-pricing-step/contact-pricing-step.component.ts
+++ b/src/app/account/new-order/steps/contact-pricing-step/contact-pricing-step.component.ts
@@ -114,11 +114,14 @@ export class ContactPricingStepComponent implements OnInit {
   }
 
   public resetCustomerSearch() {
-    this.contactFormGroup.reset();
     this.isCustomerSelected = false;
     this.isNewInvoiceContact = false;
     this.currentSelectedContact = undefined;
     this.contactFormGroup.reset();
+    if (!this.isOrderTypePrivate) {
+      this.contactFormGroup.patchValue({addressChoice: AddressChoice.OTHER_PERSON});
+      this.contactFormGroup.markAsTouched();
+    };
   }
 
   public displayCustomer(customer: IIdentity | Contact) {

--- a/src/app/account/new-order/steps/contact-pricing-step/contact-pricing-step.component.ts
+++ b/src/app/account/new-order/steps/contact-pricing-step/contact-pricing-step.component.ts
@@ -88,7 +88,7 @@ export class ContactPricingStepComponent implements OnInit {
   }
 
   public get isOrderTypePrivate(): boolean {
-    return this.orderFormGroup?.get('orderType')?.value.id === 1;
+    return this.orderFormGroup?.get('orderType')?.value?.id === 1;
   }
 
   public getLocalizedTypeName(type: IOrderType): string {

--- a/src/app/account/new-order/steps/order-type-step/order-type-step.component.html
+++ b/src/app/account/new-order/steps/order-type-step/order-type-step.component.html
@@ -5,7 +5,8 @@
     <mat-label i18n>Type de mandat</mat-label>
     <mat-select required formControlName="orderType"
                 (selectionChange)="onTypeSelected($event.value)"
-                [compareWith]="sortOrderType">
+                [compareWith]="sortOrderType"
+                >
       @for (orderType of orderTypes; track orderType) {
         <mat-option [value]="orderType">{{getLocalizedTypeName(orderType)}}</mat-option>
       }

--- a/src/app/account/new-order/steps/order-type-step/order-type-step.component.spec.ts
+++ b/src/app/account/new-order/steps/order-type-step/order-type-step.component.spec.ts
@@ -2,12 +2,12 @@ import {createOrderForm} from "@app/account/new-order/order-form.model";
 
 import {provideHttpClient} from "@angular/common/http";
 import {provideHttpClientTesting} from "@angular/common/http/testing";
-import { ComponentFixture, TestBed, tick, fakeAsync } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import {ReactiveFormsModule } from "@angular/forms";
-
-import { OrderTypeStepComponent } from './order-type-step.component';
 import { MatInputModule } from "@angular/material/input";
 import {NoopAnimationsModule} from "@angular/platform-browser/animations";
+
+import { OrderTypeStepComponent } from './order-type-step.component';
 
 describe('OrderTypeStepComponent', () => {
   let component: OrderTypeStepComponent;
@@ -96,13 +96,32 @@ describe('OrderTypeStepComponent', () => {
   });
 
   it("should block order type select if no order types loaded", () => {
-    component.orderTypes = [];
+    fixture.componentRef.setInput('orderTypes', []);
     fixture.detectChanges();
     expect(component.orderFormGroup.get('orderType')?.disabled).toBeTruthy();
 
-    component.orderTypes = [{id: 1, name: 'private'}];
+    fixture.componentRef.setInput('orderTypes', [{id: 1, name: 'private'}]);
     fixture.detectChanges();
     expect(component.orderFormGroup.get('orderType')?.disabled).toBeFalsy();
   });
 
+  it("should set default order type if no order type is selected", () => {
+    fixture.componentRef.setInput('orderTypes', [{id: 1, name: 'private'}, {id: 2, name: 'public'}]);
+    fixture.detectChanges();
+    expect(component.orderFormGroup.get('orderType')?.value).toStrictEqual({id: 1, name: 'private'});
+  });
+
+  it("should not set default order type if already selected", () => {
+    component.orderFormGroup.get('orderType')?.setValue({id: 2, name: 'public'});
+    fixture.componentRef.setInput('orderTypes', [{id: 1, name: 'private'}, {id: 2, name: 'public'}]);
+    fixture.detectChanges();
+    expect(component.orderFormGroup.get('orderType')?.value).toStrictEqual({id: 2, name: 'public'});
+  });
+
+  it("should set default order type if current value is unknown", () => {
+    component.orderFormGroup.get('orderType')?.setValue({id: 3, name: 'whatever'});
+    fixture.componentRef.setInput('orderTypes', [{id: 1, name: 'private'}, {id: 2, name: 'public'}]);
+    fixture.detectChanges();
+    expect(component.orderFormGroup.get('orderType')?.value).toStrictEqual({id: 1, name: 'private'});
+  });
 });

--- a/src/app/account/new-order/steps/order-type-step/order-type-step.component.spec.ts
+++ b/src/app/account/new-order/steps/order-type-step/order-type-step.component.spec.ts
@@ -2,10 +2,12 @@ import {createOrderForm} from "@app/account/new-order/order-form.model";
 
 import {provideHttpClient} from "@angular/common/http";
 import {provideHttpClientTesting} from "@angular/common/http/testing";
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, tick, fakeAsync } from '@angular/core/testing';
 import {ReactiveFormsModule } from "@angular/forms";
 
 import { OrderTypeStepComponent } from './order-type-step.component';
+import { MatInputModule } from "@angular/material/input";
+import {NoopAnimationsModule} from "@angular/platform-browser/animations";
 
 describe('OrderTypeStepComponent', () => {
   let component: OrderTypeStepComponent;
@@ -14,6 +16,8 @@ describe('OrderTypeStepComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [
+        MatInputModule,
+        NoopAnimationsModule,
         OrderTypeStepComponent,
         ReactiveFormsModule,
       ],
@@ -91,5 +95,14 @@ describe('OrderTypeStepComponent', () => {
     expect(emailControl?.hasError('required')).toBeTruthy();
   });
 
+  it("should block order type select if no order types loaded", () => {
+    component.orderTypes = [];
+    fixture.detectChanges();
+    expect(component.orderFormGroup.get('orderType')?.disabled).toBeTruthy();
+
+    component.orderTypes = [{id: 1, name: 'private'}];
+    fixture.detectChanges();
+    expect(component.orderFormGroup.get('orderType')?.disabled).toBeFalsy();
+  });
 
 });

--- a/src/app/account/new-order/steps/order-type-step/order-type-step.component.ts
+++ b/src/app/account/new-order/steps/order-type-step/order-type-step.component.ts
@@ -59,16 +59,18 @@ export class OrderTypeStepComponent implements OnInit, OnChanges {
   }
 
   ngOnChanges(changes: SimpleChanges): void {
-    if (!changes['orderTypes'] || !this.orderTypes?.length) {
+    if (!changes['orderTypes']) {
       return;
     }
     const typeSelect = this.orderFormGroup.get('orderType');
+    if (!this.orderTypes?.length) {
+      typeSelect?.disable();
+      return;
+    }
     if (!typeSelect?.value || this.orderTypes.every(t => t.id !== typeSelect?.value?.id)) {
       this.orderFormGroup.get('orderType')?.setValue(this.orderTypes[0]);
     }
-    console.log("HERE-BEFORE: ", typeSelect?.disabled);
     typeSelect?.enable();
-    console.log("HERE-AFTER: ", typeSelect?.disabled);
   }
 
   public sortOrderType(a: IOrderType, b: IOrderType): boolean {

--- a/src/app/account/new-order/steps/order-type-step/order-type-step.component.ts
+++ b/src/app/account/new-order/steps/order-type-step/order-type-step.component.ts
@@ -7,7 +7,7 @@ import {IProduct} from "@app/models/IProduct";
 import {ConfigService} from "@app/services/config.service";
 
 import {CommonModule} from "@angular/common";
-import {Component, Input, OnInit} from '@angular/core';
+import {Component, Input, OnChanges, OnInit, SimpleChanges} from '@angular/core';
 import {FormGroup, FormsModule, ReactiveFormsModule, Validators} from "@angular/forms";
 import {MatAutocompleteModule} from "@angular/material/autocomplete";
 import {MatButtonModule} from "@angular/material/button";
@@ -33,7 +33,7 @@ import {MatTableModule} from "@angular/material/table";
   templateUrl: './order-type-step.component.html',
   styleUrl: './order-type-step.component.scss'
 })
-export class OrderTypeStepComponent implements OnInit {
+export class OrderTypeStepComponent implements OnInit, OnChanges {
   @Input() orderFormGroup: FormGroup<OrderForm>;
   @Input() products: IProduct[] = [];
   @Input() user: Partial<IIdentity>|null = null;
@@ -56,6 +56,19 @@ export class OrderTypeStepComponent implements OnInit {
       }
       emailControl?.updateValueAndValidity();
     });
+  }
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (!changes['orderTypes'] || !this.orderTypes?.length) {
+      return;
+    }
+    const typeSelect = this.orderFormGroup.get('orderType');
+    if (!typeSelect?.value || this.orderTypes.every(t => t.id !== typeSelect?.value?.id)) {
+      this.orderFormGroup.get('orderType')?.setValue(this.orderTypes[0]);
+    }
+    console.log("HERE-BEFORE: ", typeSelect?.disabled);
+    typeSelect?.enable();
+    console.log("HERE-AFTER: ", typeSelect?.disabled);
   }
 
   public sortOrderType(a: IOrderType, b: IOrderType): boolean {


### PR DESCRIPTION
1. Properly handle only one order type
2. Disable "next" button if the form is invalid