### PR TITLE
fix(GSGGR-678): Display billing contact information on validation page

### DIFF
--- a/src/app/welcome/validate/validate.component.html
+++ b/src/app/welcome/validate/validate.component.html
@@ -38,6 +38,7 @@
     <div *ngIf="isAuthenticated && data && data.order && data.item">
       @let order = data.order;
       @let item = data.item;
+      @let contact = data.contact;
       <mat-card-header>
         <mat-card-title i18n>{{item.product.id}}. {{item.product.label}} - à valider</mat-card-title>
         <mat-card-subtitle i18n>
@@ -59,8 +60,8 @@
           <span *ngIf="order.client.phone">{{ order.client.phone }}<br></span>
           <a href="mailto:{{ order.client.email }}">{{ order.client.email }}</a>
         </p>
-        @let contact = data.contact;
-        @if (contact) {;
+        <h4 i18n>Contact de facturation:: {{contact}}::</h4>
+        @if (contact) {
           <h4 i18n>Contact de facturation</h4>
           <p>
             {{contact.first_name}} {{contact.last_name}}<br>

--- a/src/app/welcome/validate/validate.component.html
+++ b/src/app/welcome/validate/validate.component.html
@@ -60,7 +60,6 @@
           <span *ngIf="order.client.phone">{{ order.client.phone }}<br></span>
           <a href="mailto:{{ order.client.email }}">{{ order.client.email }}</a>
         </p>
-        <h4 i18n>Contact de facturation:: {{contact}}::</h4>
         @if (contact) {
           <h4 i18n>Contact de facturation</h4>
           <p>

--- a/src/app/welcome/validate/validate.component.html
+++ b/src/app/welcome/validate/validate.component.html
@@ -59,6 +59,18 @@
           <span *ngIf="order.client.phone">{{ order.client.phone }}<br></span>
           <a href="mailto:{{ order.client.email }}">{{ order.client.email }}</a>
         </p>
+        @let contact = data.contact;
+        @if (contact) {;
+          <h4 i18n>Contact de facturation</h4>
+          <p>
+            {{contact.first_name}} {{contact.last_name}}<br>
+            {{contact.street}}<br>
+            <span *ngIf="contact.street2">{{contact.street2}}<br></span>
+            {{contact.postcode}} {{contact.city}}<br>
+            <span *ngIf="contact.phone">{{ contact.phone }}<br></span>
+            <a href="mailto:{{ contact.email }}">{{ contact.email }}</a>
+          </p>
+        }
         <div class="mini-map" [id]="'mini-map-' + order.id"></div>
       </mat-card-content>
       <mat-card-actions>

--- a/src/app/welcome/validate/validate.component.spec.ts
+++ b/src/app/welcome/validate/validate.component.spec.ts
@@ -1,3 +1,4 @@
+import { IContact } from "@app/models/IContact";
 import { Order, OrderItem } from "@app/models/IOrder";
 import { ApiOrderService } from "@app/services/api-order.service";
 import { AuthService } from "@app/services/auth.service";
@@ -45,16 +46,25 @@ const fakeOrder = {
   },
 } as unknown as Order;
 
+const fakeContact = {
+  first_name: "fake first name",
+  last_name: "fake last name",
+  email: "fake email",
+} as unknown as IContact;
+
 describe('ValidateComponent', () => {
   let fixture: ComponentFixture<ValidateComponent>;
   let params: Subject<Params>;
   let items: Subject<OrderItem | null>;
   let orders: Subject<Order | null>;
+  let contacts: Subject<IContact | null>;
 
   beforeEach(() => {
     params = new BehaviorSubject<Params>({ token: "token" });
     orders = new Subject<Order>();
     items = new Subject<OrderItem>();
+    contacts = new Subject<IContact>();
+
     TestBed.configureTestingModule({
       imports: [
         CommonModule, LowerCasePipe, MatButtonModule, MatCardModule, MatProgressSpinnerModule,
@@ -71,6 +81,7 @@ describe('ValidateComponent', () => {
           provide: ApiOrderService, useValue: {
             getOrderItemByToken: vi.fn().mockImplementation(() => items),
             getOrderByUUID: vi.fn().mockImplementation(() => orders),
+            getContact: vi.fn().mockImplementation(() => contacts)
           }
         },
         { provide: ConfigService, useClass: ConfigServiceMock },
@@ -122,5 +133,27 @@ describe('ValidateComponent', () => {
     fixture.detectChanges();
     expect(el.querySelector("mat-card-content mat-spinner")).toBeFalsy();
     expect(el.querySelector("mat-card-content").innerHTML).toContain("Titre du mandat");
+  });
+
+  it('should show contact information if exist', () => {
+    const el = fixture.nativeElement;
+    vi.mock('@app/helpers/geoHelper', () => {
+      return {
+        generateMiniMap: async () => ({ minimap: null, vectorSource: null }),
+        displayMiniMap: async () => ({})
+      };
+    });
+    items.next(fakeItem);
+    orders.next({client: fakeOrder.client, invoice_contact: 123} as unknown as Order);
+    contacts.next(fakeContact);
+    fixture.detectChanges();
+    expect(el.querySelector("mat-card-content mat-spinner")).toBeFalsy();
+    expect(el.querySelector("mat-card-content").innerHTML).toContain("Titre du mandat");
+
+    const cardContent = el.querySelector("mat-card-content").innerHTML;
+    expect(cardContent).includes("Contact de facturation");
+    expect(cardContent).includes(fakeContact.first_name);
+    expect(cardContent).includes(fakeContact.last_name);
+    expect(cardContent).includes(fakeContact.email);
   });
 });

--- a/src/app/welcome/validate/validate.component.ts
+++ b/src/app/welcome/validate/validate.component.ts
@@ -1,4 +1,5 @@
 import { generateMiniMap, displayMiniMap } from '@app/helpers/geoHelper';
+import {IContact} from "@app/models/IContact";
 import { IOrderItem, Order } from '@app/models/IOrder';
 import { ApiOrderService } from '@app/services/api-order.service';
 import { AuthService } from '@app/services/auth.service';
@@ -6,14 +7,20 @@ import { ConfigService } from '@app/services/config.service';
 import { MapService } from '@app/services/map.service';
 
 import { CommonModule, LowerCasePipe } from '@angular/common';
-import { Component, HostBinding, OnDestroy, OnInit } from '@angular/core';
+import {Component, DestroyRef, HostBinding, OnInit} from '@angular/core';
+import {takeUntilDestroyed} from '@angular/core/rxjs-interop';
 import { MatButtonModule } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
-import { Observable, of, Subject } from 'rxjs';
-import { filter, map, mergeMap, skipUntil, takeUntil } from 'rxjs/operators';
+import { Observable, of } from 'rxjs';
+import {filter, map, switchMap, skipUntil, take} from 'rxjs/operators';
 
+interface ValidationData {
+  order: Order | null;
+  item: IOrderItem | null;
+  contact: IContact | null;
+}
 
 @Component({
   selector: 'gs2-validate',
@@ -24,14 +31,13 @@ import { filter, map, mergeMap, skipUntil, takeUntil } from 'rxjs/operators';
     RouterLink
   ],
 })
-export class ValidateComponent implements OnInit, OnDestroy {
+export class ValidateComponent implements OnInit {
 
   @HostBinding('class') class = 'main-container';
 
-  private onDestroy$ = new Subject<void>();
-  token$: Observable<string>;
-  orderData$: Observable<{ order: Order | null, item: IOrderItem | null }>;
-  isAuthenticated$ = this.auth.isAuthenticated;
+  public token$: Observable<string>;
+  public orderData$: Observable<ValidationData>;
+  public isAuthenticated$ = this.auth.isAuthenticated;
 
   constructor(
     private readonly apiOrderService: ApiOrderService,
@@ -39,23 +45,39 @@ export class ValidateComponent implements OnInit, OnDestroy {
     private readonly router: Router,
     private readonly configService: ConfigService,
     private readonly auth: AuthService,
-    private readonly mapService: MapService) {
+    private readonly mapService: MapService,
+    private readonly destroyRef: DestroyRef,
+    ) {
 
-    this.token$ = this.route.params
-      .pipe(
-        takeUntil(this.onDestroy$),
-        map(params => params.token)
-      );
+    this.token$ = this.route.params.pipe(takeUntilDestroyed(this.destroyRef), map(params => params.token));
   }
 
-  ngOnInit(): void {
+  private initValidationData(token: string): Observable<ValidationData> {
+    return this.apiOrderService.getOrderItemByToken(token).pipe(
+      map(item => ({ item, order: null, contact: null }))
+    );
+  }
+
+  private addOrderData(data: ValidationData): Observable<ValidationData> {
+    if (!data.item?.order_guid) {
+      return of(data);
+    }
+    return this.apiOrderService.getOrderByUUID(data.item.order_guid).pipe(map(order => ({ ...data, order })));
+  }
+
+  private addContactData(data: ValidationData): Observable<ValidationData> {
+    if (!data.order?.invoice_contact) {
+      return of(data);
+    }
+    return this.apiOrderService.getContact(data.order.invoice_contact).pipe(map(contact => ({ ...data, contact })));
+  }
+
+  public ngOnInit(): void {
     this.orderData$ = this.token$.pipe(
       skipUntil(this.isAuthenticated$.pipe(filter((value) => value))),
-      mergeMap(token => this.apiOrderService.getOrderItemByToken(token)),
-      mergeMap(
-        item => item ? this.apiOrderService.getOrderByUUID(item.order_guid).pipe(
-          map(order => ({ order, item }))) : of({ order: null, item: null })
-      )
+      switchMap(token => this.initValidationData(token)),
+      switchMap(data => this.addOrderData(data)),
+      switchMap(data => this.addContactData(data))
     );
 
     this.orderData$.pipe(
@@ -76,18 +98,12 @@ export class ValidateComponent implements OnInit, OnDestroy {
     });
   }
 
-  ngOnDestroy(): void {
-    this.onDestroy$.next();
-  }
-
-  proceedOrder(isAccepted: boolean) {
-    this.token$.subscribe(token => {
-      this.apiOrderService.updateOrderItemStatus(token, isAccepted).subscribe(async confirmed => {
-        if (confirmed) {
-          await this.router.navigate(['/welcome']);
-        }
-      });
-    });
+  public proceedOrder(isAccepted: boolean) {
+    this.token$.pipe(
+        switchMap(token => this.apiOrderService.updateOrderItemStatus(token, isAccepted)),
+        filter(confirmed => confirmed),
+        take(1)
+      ).subscribe(() =>  this.router.navigate(['/welcome']));
   }
 }
 

--- a/src/locale/messages.de.xlf
+++ b/src/locale/messages.de.xlf
@@ -338,7 +338,7 @@
         <target> Auf dieser Seite können Sie die Verwendung eines Produkts bei einer GeoShop Bestellung bewilligen oder ablehnen. </target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/welcome/validate/validate.component.html</context>
-          <context context-type="linenumber">44</context>
+          <context context-type="linenumber">45</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8849186627502254446" datatype="html">
@@ -346,7 +346,7 @@
         <target>Beschreibung der Bestellung</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/account/new-order/steps/order-type-step/order-type-step.component.html</context>
-          <context context-type="linenumber">18</context>
+          <context context-type="linenumber">19</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8627725908406716847" datatype="html">
@@ -354,7 +354,7 @@
         <target> Die Bezeichnung enthält ungültige Zeichen (Klammern, Anführungszeichen, o.ä.)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/account/new-order/steps/order-type-step/order-type-step.component.html</context>
-          <context context-type="linenumber">24</context>
+          <context context-type="linenumber">25</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1354754757426725771" datatype="html">
@@ -362,7 +362,7 @@
         <target>Verwendungszweck</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/account/new-order/steps/order-type-step/order-type-step.component.html</context>
-          <context context-type="linenumber">29</context>
+          <context context-type="linenumber">30</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5988593865166963203" datatype="html">
@@ -370,7 +370,7 @@
         <target>Kurze Beschreibung des Auftrags</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/account/new-order/steps/order-type-step/order-type-step.component.html</context>
-          <context context-type="linenumber">31</context>
+          <context context-type="linenumber">32</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4189701300328622803" datatype="html">
@@ -378,7 +378,7 @@
         <target>Ihre Rechnungsreferenz</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/account/new-order/steps/order-type-step/order-type-step.component.html</context>
-          <context context-type="linenumber">39</context>
+          <context context-type="linenumber">40</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5938060479305453476" datatype="html">
@@ -386,7 +386,7 @@
         <target state="new">Die Daten werden an die e-Mail Adresse des aktuellen Benutzers gesendet: <x id="INTERPOLATION" equiv-text="{{(currentUser$|async)?.email}}"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/account/new-order/steps/order-type-step/order-type-step.component.html</context>
-          <context context-type="linenumber">46</context>
+          <context context-type="linenumber">47</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1071751312378015303" datatype="html">
@@ -394,7 +394,7 @@
         <target>Abweichende Lieferadresse</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/account/new-order/steps/order-type-step/order-type-step.component.html</context>
-          <context context-type="linenumber">48</context>
+          <context context-type="linenumber">49</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5457045476183220490" datatype="html">
@@ -402,7 +402,7 @@
         <target>Erfassung der e-Mail-Lieferadresse</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/account/new-order/steps/order-type-step/order-type-step.component.html</context>
-          <context context-type="linenumber">52</context>
+          <context context-type="linenumber">53</context>
         </context-group>
       </trans-unit>
       <trans-unit id="785075939257175908" datatype="html">
@@ -410,7 +410,7 @@
         <target>Ungültige e-Mail Adresse</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/account/new-order/steps/order-type-step/order-type-step.component.html</context>
-          <context context-type="linenumber">57</context>
+          <context context-type="linenumber">58</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2351751452789003122" datatype="html">
@@ -442,7 +442,7 @@
         <target> Für einen Autrag der Art &quot;<x id="INTERPOLATION" equiv-text="{{ getLocalizedTypeName(orderFormGroup.get(&apos;orderType&apos;)?.value) }}"/>&quot; müssen Sie die Kontaktdaten des Mandanten ausfüllen. </target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/account/new-order/steps/contact-pricing-step/contact-pricing-step.component.html</context>
-          <context context-type="linenumber">12</context>
+          <context context-type="linenumber">11</context>
         </context-group>
       </trans-unit>
       <trans-unit id="913585467725084758" datatype="html">
@@ -450,7 +450,7 @@
         <target>Suche in den Kontakten</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/account/new-order/steps/contact-pricing-step/contact-pricing-step.component.html</context>
-          <context context-type="linenumber">20</context>
+          <context context-type="linenumber">19</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4367093015972281732" datatype="html">
@@ -458,7 +458,7 @@
         <target>Einen neuen Kontakt erstellen</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/account/new-order/steps/contact-pricing-step/contact-pricing-step.component.html</context>
-          <context context-type="linenumber">38</context>
+          <context context-type="linenumber">37</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8542514497321699881" datatype="html">
@@ -466,7 +466,7 @@
         <target>Änderungen verwerfen</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/account/new-order/steps/contact-pricing-step/contact-pricing-step.component.html</context>
-          <context context-type="linenumber">43</context>
+          <context context-type="linenumber">42</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8341572613423434340" datatype="html">
@@ -474,7 +474,7 @@
         <target>Diesen Kontakt entfernen</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/account/new-order/steps/contact-pricing-step/contact-pricing-step.component.html</context>
-          <context context-type="linenumber">50</context>
+          <context context-type="linenumber">49</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8203024106711668685" datatype="html">
@@ -482,7 +482,7 @@
         <target>Vorname</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/account/new-order/steps/contact-pricing-step/contact-pricing-step.component.html</context>
-          <context context-type="linenumber">62</context>
+          <context context-type="linenumber">60</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/account/profile/modify-profile.component.html</context>
@@ -498,7 +498,7 @@
         <target>Name</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/account/new-order/steps/contact-pricing-step/contact-pricing-step.component.html</context>
-          <context context-type="linenumber">69</context>
+          <context context-type="linenumber">67</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/account/profile/modify-profile.component.html</context>
@@ -518,7 +518,7 @@
         <target>e-Mail Adresse des Mandanten</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/account/new-order/steps/contact-pricing-step/contact-pricing-step.component.html</context>
-          <context context-type="linenumber">75</context>
+          <context context-type="linenumber">73</context>
         </context-group>
       </trans-unit>
       <trans-unit id="821653174536665893" datatype="html">
@@ -526,7 +526,7 @@
         <target>Unternehmen</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/account/new-order/steps/contact-pricing-step/contact-pricing-step.component.html</context>
-          <context context-type="linenumber">84</context>
+          <context context-type="linenumber">82</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3212644565738188561" datatype="html">
@@ -534,7 +534,7 @@
         <target>Unternehmens-Identifikationsnummer</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/account/new-order/steps/contact-pricing-step/contact-pricing-step.component.html</context>
-          <context context-type="linenumber">89</context>
+          <context context-type="linenumber">87</context>
         </context-group>
       </trans-unit>
       <trans-unit id="new-order.bad_IDE_format" datatype="html">
@@ -542,7 +542,7 @@
         <target>Ungültiges Format, Eingabemuster: CHE-012.345.678 </target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/account/new-order/steps/contact-pricing-step/contact-pricing-step.component.html</context>
-          <context context-type="linenumber">92</context>
+          <context context-type="linenumber">90</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7451848863370733592" datatype="html">
@@ -550,7 +550,7 @@
         <target>Telefon des Mandanten</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/account/new-order/steps/contact-pricing-step/contact-pricing-step.component.html</context>
-          <context context-type="linenumber">98</context>
+          <context context-type="linenumber">96</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1815195286714301387" datatype="html">
@@ -558,7 +558,7 @@
         <target>Adresse</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/account/new-order/steps/contact-pricing-step/contact-pricing-step.component.html</context>
-          <context context-type="linenumber">113</context>
+          <context context-type="linenumber">111</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6840029554610349837" datatype="html">
@@ -566,7 +566,7 @@
         <target>Adresszusatz</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/account/new-order/steps/contact-pricing-step/contact-pricing-step.component.html</context>
-          <context context-type="linenumber">118</context>
+          <context context-type="linenumber">116</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/account/profile/modify-profile.component.html</context>
@@ -586,7 +586,7 @@
         <target>Postleitzahl</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/account/new-order/steps/contact-pricing-step/contact-pricing-step.component.html</context>
-          <context context-type="linenumber">123</context>
+          <context context-type="linenumber">121</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/account/profile/modify-profile.component.html</context>
@@ -606,7 +606,7 @@
         <target>Stadt</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/account/new-order/steps/contact-pricing-step/contact-pricing-step.component.html</context>
-          <context context-type="linenumber">128</context>
+          <context context-type="linenumber">126</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/account/profile/modify-profile.component.html</context>
@@ -626,7 +626,7 @@
         <target>Land</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/account/new-order/steps/contact-pricing-step/contact-pricing-step.component.html</context>
-          <context context-type="linenumber">133</context>
+          <context context-type="linenumber">131</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/account/profile/modify-profile.component.html</context>
@@ -646,7 +646,7 @@
         <target>Übersicht der Bestellung</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/account/new-order/new-order.component.html</context>
-          <context context-type="linenumber">38</context>
+          <context context-type="linenumber">39</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1591895368052596259" datatype="html">
@@ -722,7 +722,7 @@
         <target>Jetzt bestellen</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/account/new-order/new-order.component.ts</context>
-          <context context-type="linenumber">95</context>
+          <context context-type="linenumber">97</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8353026757372386829" datatype="html">
@@ -730,7 +730,7 @@
         <target>Kostenvoranschlag anfragen</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/account/new-order/new-order.component.ts</context>
-          <context context-type="linenumber">96</context>
+          <context context-type="linenumber">98</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1711750570766225138" datatype="html">
@@ -738,7 +738,7 @@
         <target>Stornieren</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/account/new-order/steps/contact-pricing-step/contact-pricing-step.component.ts</context>
-          <context context-type="linenumber">144</context>
+          <context context-type="linenumber">156</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/account/orders/order/order.component.ts</context>
@@ -758,7 +758,7 @@
         <target>Entfernen</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/account/new-order/steps/contact-pricing-step/contact-pricing-step.component.ts</context>
-          <context context-type="linenumber">145</context>
+          <context context-type="linenumber">157</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/account/orders/order/order.component.ts</context>
@@ -1464,13 +1464,17 @@
           <context context-type="sourcefile">src/app/constants.ts</context>
           <context context-type="linenumber">53</context>
         </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/constants.ts</context>
+          <context context-type="linenumber">58</context>
+        </context-group>
       </trans-unit>
       <trans-unit id="search.category.unknown" datatype="html">
         <source>Général</source>
         <target>Allgemein</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/constants.ts</context>
-          <context context-type="linenumber">60</context>
+          <context context-type="linenumber">61</context>
         </context-group>
       </trans-unit>
       <trans-unit id="catalog_productSearch" datatype="html">
@@ -1802,7 +1806,7 @@
         <target>Bezeichung des Mandats <x id="INTERPOLATION" equiv-text="{{order.order_type | lowercase}}"/>:</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/welcome/validate/validate.component.html</context>
-          <context context-type="linenumber">48</context>
+          <context context-type="linenumber">49</context>
         </context-group>
       </trans-unit>
       <trans-unit id="36900456667458058" datatype="html">
@@ -1810,7 +1814,7 @@
         <target>Durch den Kunden übermittelte Beschreibung:</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/welcome/validate/validate.component.html</context>
-          <context context-type="linenumber">50</context>
+          <context context-type="linenumber">51</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5648951943054133937" datatype="html">
@@ -1818,7 +1822,7 @@
         <target>Kundenangaben:</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/welcome/validate/validate.component.html</context>
-          <context context-type="linenumber">52</context>
+          <context context-type="linenumber">53</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7391218527938739133" datatype="html">
@@ -1826,7 +1830,7 @@
         <target>ANNEHMEN</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/welcome/validate/validate.component.html</context>
-          <context context-type="linenumber">65</context>
+          <context context-type="linenumber">77</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6754428430652088774" datatype="html">
@@ -1834,7 +1838,7 @@
         <target>ABLEHNEN</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/welcome/validate/validate.component.html</context>
-          <context context-type="linenumber">66</context>
+          <context context-type="linenumber">78</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4515716860476357376" datatype="html">
@@ -1842,7 +1846,7 @@
         <target state="new">Choisir l&apos;email de livraison</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/account/new-order/steps/order-type-step/order-type-step.component.html</context>
-          <context context-type="linenumber">45</context>
+          <context context-type="linenumber">46</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3641166415384919072" datatype="html">
@@ -1982,7 +1986,7 @@
         <target state="new"><x id="INTERPOLATION" equiv-text="{{item.product.id}}"/>. <x id="INTERPOLATION_1" equiv-text="{{item.product.label}}"/> - à valider</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/welcome/validate/validate.component.html</context>
-          <context context-type="linenumber">42</context>
+          <context context-type="linenumber">43</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8531193569169880344" datatype="html">
@@ -1990,15 +1994,23 @@
         <target>Möchten Sie den Kontakt wirklich löschen &lt;b style=&apos;color:#26a59a;&apos;&gt;<x id="PH" equiv-text="contact.first_name"/> <x id="PH_1" equiv-text="contact.last_name"/>&lt;/b&gt; ?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/account/new-order/steps/contact-pricing-step/contact-pricing-step.component.ts</context>
-          <context context-type="linenumber">147</context>
+          <context context-type="linenumber">159</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="8227723705151707399" datatype="html">
+      <trans-unit id="3236774620090971707" datatype="html">
         <source>Contact ajouté &quot;<x id="PH" equiv-text="contact.first_name"/> <x id="PH_1" equiv-text="contact.last_name"/>&quot;</source>
         <target>Kontakt hinzugefügt &quot;<x id="PH" equiv-text="contact.first_name"/> <x id="PH_1" equiv-text="contact.last_name"/>&quot;</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/services/api-order.service.ts</context>
           <context context-type="linenumber">283</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="1719424001991628872" datatype="html">
+        <source>Contact de facturation</source>
+        <target>Rechnungskontakt</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/welcome/validate/validate.component.html</context>
+          <context context-type="linenumber">64</context>
         </context-group>
       </trans-unit>
     </body>

--- a/src/locale/messages.en.xlf
+++ b/src/locale/messages.en.xlf
@@ -243,7 +243,7 @@
         <target>Title of the mandate</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/account/new-order/steps/order-type-step/order-type-step.component.html</context>
-          <context context-type="linenumber">18</context>
+          <context context-type="linenumber">19</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8627725908406716847" datatype="html">
@@ -251,7 +251,7 @@
         <target>The title contains unsupported characters (parentheses, quotes, etc.)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/account/new-order/steps/order-type-step/order-type-step.component.html</context>
-          <context context-type="linenumber">24</context>
+          <context context-type="linenumber">25</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1354754757426725771" datatype="html">
@@ -259,7 +259,7 @@
         <target>Description of the mandate</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/account/new-order/steps/order-type-step/order-type-step.component.html</context>
-          <context context-type="linenumber">29</context>
+          <context context-type="linenumber">30</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4189701300328622803" datatype="html">
@@ -267,7 +267,7 @@
         <target>Your reference on the invoice</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/account/new-order/steps/order-type-step/order-type-step.component.html</context>
-          <context context-type="linenumber">39</context>
+          <context context-type="linenumber">40</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5938060479305453476" datatype="html">
@@ -275,7 +275,7 @@
         <target state="new">The data will be sent to the current user&apos;s email address: <x id="INTERPOLATION" equiv-text="{{(currentUser$|async)?.email}}"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/account/new-order/steps/order-type-step/order-type-step.component.html</context>
-          <context context-type="linenumber">46</context>
+          <context context-type="linenumber">47</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1071751312378015303" datatype="html">
@@ -283,7 +283,7 @@
         <target>Different delivery address for the data</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/account/new-order/steps/order-type-step/order-type-step.component.html</context>
-          <context context-type="linenumber">48</context>
+          <context context-type="linenumber">49</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5457045476183220490" datatype="html">
@@ -291,7 +291,7 @@
         <target>Enter the delivery email address</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/account/new-order/steps/order-type-step/order-type-step.component.html</context>
-          <context context-type="linenumber">52</context>
+          <context context-type="linenumber">53</context>
         </context-group>
       </trans-unit>
       <trans-unit id="785075939257175908" datatype="html">
@@ -299,7 +299,7 @@
         <target>Invalid email address</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/account/new-order/steps/order-type-step/order-type-step.component.html</context>
-          <context context-type="linenumber">57</context>
+          <context context-type="linenumber">58</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2351751452789003122" datatype="html">
@@ -331,7 +331,7 @@
         <target>Principal email</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/account/new-order/steps/contact-pricing-step/contact-pricing-step.component.html</context>
-          <context context-type="linenumber">75</context>
+          <context context-type="linenumber">73</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3212644565738188561" datatype="html">
@@ -339,7 +339,7 @@
         <target>Business identification number (IDE)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/account/new-order/steps/contact-pricing-step/contact-pricing-step.component.html</context>
-          <context context-type="linenumber">89</context>
+          <context context-type="linenumber">87</context>
         </context-group>
       </trans-unit>
       <trans-unit id="new-order.bad_IDE_format" datatype="html">
@@ -347,7 +347,7 @@
         <target>Incorrect IDE number format, accepted: CHE-012.345.678 </target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/account/new-order/steps/contact-pricing-step/contact-pricing-step.component.html</context>
-          <context context-type="linenumber">92</context>
+          <context context-type="linenumber">90</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7451848863370733592" datatype="html">
@@ -355,7 +355,7 @@
         <target>Principal phone</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/account/new-order/steps/contact-pricing-step/contact-pricing-step.component.html</context>
-          <context context-type="linenumber">98</context>
+          <context context-type="linenumber">96</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1815195286714301387" datatype="html">
@@ -363,7 +363,7 @@
         <target>Address</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/account/new-order/steps/contact-pricing-step/contact-pricing-step.component.html</context>
-          <context context-type="linenumber">113</context>
+          <context context-type="linenumber">111</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6840029554610349837" datatype="html">
@@ -371,7 +371,7 @@
         <target>Address complement</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/account/new-order/steps/contact-pricing-step/contact-pricing-step.component.html</context>
-          <context context-type="linenumber">118</context>
+          <context context-type="linenumber">116</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/account/profile/modify-profile.component.html</context>
@@ -391,7 +391,7 @@
         <target>Postal code</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/account/new-order/steps/contact-pricing-step/contact-pricing-step.component.html</context>
-          <context context-type="linenumber">123</context>
+          <context context-type="linenumber">121</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/account/profile/modify-profile.component.html</context>
@@ -411,7 +411,7 @@
         <target>City</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/account/new-order/steps/contact-pricing-step/contact-pricing-step.component.html</context>
-          <context context-type="linenumber">128</context>
+          <context context-type="linenumber">126</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/account/profile/modify-profile.component.html</context>
@@ -431,7 +431,7 @@
         <target>Country</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/account/new-order/steps/contact-pricing-step/contact-pricing-step.component.html</context>
-          <context context-type="linenumber">133</context>
+          <context context-type="linenumber">131</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/account/profile/modify-profile.component.html</context>
@@ -451,7 +451,7 @@
         <target>Order preview</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/account/new-order/new-order.component.html</context>
-          <context context-type="linenumber">38</context>
+          <context context-type="linenumber">39</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1591895368052596259" datatype="html">
@@ -527,7 +527,7 @@
         <target>Confirm order</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/account/new-order/new-order.component.ts</context>
-          <context context-type="linenumber">95</context>
+          <context context-type="linenumber">97</context>
         </context-group>
       </trans-unit>
       <trans-unit id="order.delete" datatype="html">
@@ -803,7 +803,7 @@
         <target>First name</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/account/new-order/steps/contact-pricing-step/contact-pricing-step.component.html</context>
-          <context context-type="linenumber">62</context>
+          <context context-type="linenumber">60</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/account/profile/modify-profile.component.html</context>
@@ -819,7 +819,7 @@
         <target>Last name</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/account/new-order/steps/contact-pricing-step/contact-pricing-step.component.html</context>
-          <context context-type="linenumber">69</context>
+          <context context-type="linenumber">67</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/account/profile/modify-profile.component.html</context>
@@ -1355,7 +1355,7 @@
         <target state="translated">Provide a brief description of the mandate...</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/account/new-order/steps/order-type-step/order-type-step.component.html</context>
-          <context context-type="linenumber">31</context>
+          <context context-type="linenumber">32</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4515716860476357376" datatype="html">
@@ -1363,7 +1363,7 @@
         <target state="translated">Choose the delivery email</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/account/new-order/steps/order-type-step/order-type-step.component.html</context>
-          <context context-type="linenumber">45</context>
+          <context context-type="linenumber">46</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5929531880571632059" datatype="html">
@@ -1371,7 +1371,7 @@
         <target state="translated">Please specify the contact details of the third party for a &quot;<x id="INTERPOLATION" equiv-text="{{ getLocalizedTypeName(orderFormGroup.get(&apos;orderType&apos;)?.value) }}"/>&quot; type mandate. </target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/account/new-order/steps/contact-pricing-step/contact-pricing-step.component.html</context>
-          <context context-type="linenumber">12</context>
+          <context context-type="linenumber">11</context>
         </context-group>
       </trans-unit>
       <trans-unit id="913585467725084758" datatype="html">
@@ -1379,7 +1379,7 @@
         <target state="translated">Look up in my contacts</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/account/new-order/steps/contact-pricing-step/contact-pricing-step.component.html</context>
-          <context context-type="linenumber">20</context>
+          <context context-type="linenumber">19</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4367093015972281732" datatype="html">
@@ -1387,7 +1387,7 @@
         <target state="translated">Add a new contact</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/account/new-order/steps/contact-pricing-step/contact-pricing-step.component.html</context>
-          <context context-type="linenumber">38</context>
+          <context context-type="linenumber">37</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8542514497321699881" datatype="html">
@@ -1395,7 +1395,7 @@
         <target state="translated">Discard changes</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/account/new-order/steps/contact-pricing-step/contact-pricing-step.component.html</context>
-          <context context-type="linenumber">43</context>
+          <context context-type="linenumber">42</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8341572613423434340" datatype="html">
@@ -1403,7 +1403,7 @@
         <target state="translated">Delete this contact</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/account/new-order/steps/contact-pricing-step/contact-pricing-step.component.html</context>
-          <context context-type="linenumber">50</context>
+          <context context-type="linenumber">49</context>
         </context-group>
       </trans-unit>
       <trans-unit id="821653174536665893" datatype="html">
@@ -1411,7 +1411,7 @@
         <target state="translated">Company</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/account/new-order/steps/contact-pricing-step/contact-pricing-step.component.html</context>
-          <context context-type="linenumber">84</context>
+          <context context-type="linenumber">82</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8353026757372386829" datatype="html">
@@ -1419,7 +1419,7 @@
         <target state="translated">Request a quote</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/account/new-order/new-order.component.ts</context>
-          <context context-type="linenumber">96</context>
+          <context context-type="linenumber">98</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1711750570766225138" datatype="html">
@@ -1427,7 +1427,7 @@
         <target state="translated">Cancel</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/account/new-order/steps/contact-pricing-step/contact-pricing-step.component.ts</context>
-          <context context-type="linenumber">144</context>
+          <context context-type="linenumber">156</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/account/orders/order/order.component.ts</context>
@@ -1447,7 +1447,7 @@
         <target state="translated">Delete</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/account/new-order/steps/contact-pricing-step/contact-pricing-step.component.ts</context>
-          <context context-type="linenumber">145</context>
+          <context context-type="linenumber">157</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/account/orders/order/order.component.ts</context>
@@ -1661,13 +1661,17 @@
           <context context-type="sourcefile">src/app/constants.ts</context>
           <context context-type="linenumber">53</context>
         </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/constants.ts</context>
+          <context context-type="linenumber">58</context>
+        </context-group>
       </trans-unit>
       <trans-unit id="search.category.unknown" datatype="html">
         <source>Général</source>
         <target state="new">Général</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/constants.ts</context>
-          <context context-type="linenumber">60</context>
+          <context context-type="linenumber">61</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5300981229662517671" datatype="html">
@@ -1815,7 +1819,7 @@
         <target state="translated"> This page lets you approve or revoke the use of a product ordered from the geoshop. </target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/welcome/validate/validate.component.html</context>
-          <context context-type="linenumber">44</context>
+          <context context-type="linenumber">45</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1272421211953350782" datatype="html">
@@ -1823,7 +1827,7 @@
         <target state="translated">Mandate title <x id="INTERPOLATION" equiv-text="{{order.order_type | lowercase}}"/>:</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/welcome/validate/validate.component.html</context>
-          <context context-type="linenumber">48</context>
+          <context context-type="linenumber">49</context>
         </context-group>
       </trans-unit>
       <trans-unit id="36900456667458058" datatype="html">
@@ -1831,7 +1835,7 @@
         <target state="translated">Client-provided description:</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/welcome/validate/validate.component.html</context>
-          <context context-type="linenumber">50</context>
+          <context context-type="linenumber">51</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5648951943054133937" datatype="html">
@@ -1839,7 +1843,7 @@
         <target state="translated">Client details:</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/welcome/validate/validate.component.html</context>
-          <context context-type="linenumber">52</context>
+          <context context-type="linenumber">53</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7391218527938739133" datatype="html">
@@ -1847,7 +1851,7 @@
         <target state="translated">ACCEPT</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/welcome/validate/validate.component.html</context>
-          <context context-type="linenumber">65</context>
+          <context context-type="linenumber">77</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6754428430652088774" datatype="html">
@@ -1855,7 +1859,7 @@
         <target state="translated">REFUSE</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/welcome/validate/validate.component.html</context>
-          <context context-type="linenumber">66</context>
+          <context context-type="linenumber">78</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8857159515510586089" datatype="html">
@@ -1971,7 +1975,7 @@
         <target state="new"><x id="INTERPOLATION" equiv-text="{{item.product.id}}"/>. <x id="INTERPOLATION_1" equiv-text="{{item.product.label}}"/> - à valider</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/welcome/validate/validate.component.html</context>
-          <context context-type="linenumber">42</context>
+          <context context-type="linenumber">43</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8531193569169880344" datatype="html">
@@ -1979,15 +1983,23 @@
         <target>Are you sure you want to delete the contact &lt;b style=&apos;color:#26a59a;&apos;&gt;<x id="PH" equiv-text="contact.first_name"/> <x id="PH_1" equiv-text="contact.last_name"/>&lt;/b&gt; ?</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/account/new-order/steps/contact-pricing-step/contact-pricing-step.component.ts</context>
-          <context context-type="linenumber">147</context>
+          <context context-type="linenumber">159</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="8227723705151707399" datatype="html">
+      <trans-unit id="3236774620090971707" datatype="html">
         <source>Contact ajouté &quot;<x id="PH" equiv-text="contact.first_name"/> <x id="PH_1" equiv-text="contact.last_name"/>&quot;</source>
         <target>Added contact &quot;<x id="PH" equiv-text="contact.first_name"/> <x id="PH_1" equiv-text="contact.last_name"/>&quot;</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/services/api-order.service.ts</context>
           <context context-type="linenumber">283</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="1719424001991628872" datatype="html">
+        <source>Contact de facturation</source>
+        <target>Billing contact</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/welcome/validate/validate.component.html</context>
+          <context context-type="linenumber">64</context>
         </context-group>
       </trans-unit>
     </body>

--- a/src/locale/messages.xlf
+++ b/src/locale/messages.xlf
@@ -20,21 +20,21 @@
         <source>Aperçu de la commande</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/account/new-order/new-order.component.html</context>
-          <context context-type="linenumber">38</context>
+          <context context-type="linenumber">39</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7079597122499354381" datatype="html">
         <source>Acheter maintenant</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/account/new-order/new-order.component.ts</context>
-          <context context-type="linenumber">95</context>
+          <context context-type="linenumber">97</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8353026757372386829" datatype="html">
         <source>Demander un devis</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/account/new-order/new-order.component.ts</context>
-          <context context-type="linenumber">96</context>
+          <context context-type="linenumber">98</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6502978400573686857" datatype="html">
@@ -55,42 +55,42 @@
         <source> Vous devez spécifier les informations de contact du tiers pour un mandat de type &quot;<x id="INTERPOLATION" equiv-text="{{ getLocalizedTypeName(orderFormGroup.get(&apos;orderType&apos;)?.value) }}"/>&quot;. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/account/new-order/steps/contact-pricing-step/contact-pricing-step.component.html</context>
-          <context context-type="linenumber">12</context>
+          <context context-type="linenumber">11</context>
         </context-group>
       </trans-unit>
       <trans-unit id="913585467725084758" datatype="html">
         <source>Rechercher dans mes contacts</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/account/new-order/steps/contact-pricing-step/contact-pricing-step.component.html</context>
-          <context context-type="linenumber">20</context>
+          <context context-type="linenumber">19</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4367093015972281732" datatype="html">
         <source>Créer un nouveau contact</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/account/new-order/steps/contact-pricing-step/contact-pricing-step.component.html</context>
-          <context context-type="linenumber">38</context>
+          <context context-type="linenumber">37</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8542514497321699881" datatype="html">
         <source>Annuler les changements</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/account/new-order/steps/contact-pricing-step/contact-pricing-step.component.html</context>
-          <context context-type="linenumber">43</context>
+          <context context-type="linenumber">42</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8341572613423434340" datatype="html">
         <source>Supprimer ce contact</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/account/new-order/steps/contact-pricing-step/contact-pricing-step.component.html</context>
-          <context context-type="linenumber">50</context>
+          <context context-type="linenumber">49</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8203024106711668685" datatype="html">
         <source>Prénom</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/account/new-order/steps/contact-pricing-step/contact-pricing-step.component.html</context>
-          <context context-type="linenumber">62</context>
+          <context context-type="linenumber">60</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/account/profile/modify-profile.component.html</context>
@@ -105,7 +105,7 @@
         <source>Nom</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/account/new-order/steps/contact-pricing-step/contact-pricing-step.component.html</context>
-          <context context-type="linenumber">69</context>
+          <context context-type="linenumber">67</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/account/profile/modify-profile.component.html</context>
@@ -124,49 +124,49 @@
         <source>Courriel mandant</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/account/new-order/steps/contact-pricing-step/contact-pricing-step.component.html</context>
-          <context context-type="linenumber">75</context>
+          <context context-type="linenumber">73</context>
         </context-group>
       </trans-unit>
       <trans-unit id="821653174536665893" datatype="html">
         <source>Société</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/account/new-order/steps/contact-pricing-step/contact-pricing-step.component.html</context>
-          <context context-type="linenumber">84</context>
+          <context context-type="linenumber">82</context>
         </context-group>
       </trans-unit>
       <trans-unit id="3212644565738188561" datatype="html">
         <source>Numéro d’identification des entreprises (IDE)</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/account/new-order/steps/contact-pricing-step/contact-pricing-step.component.html</context>
-          <context context-type="linenumber">89</context>
+          <context context-type="linenumber">87</context>
         </context-group>
       </trans-unit>
       <trans-unit id="new-order.bad_IDE_format" datatype="html">
         <source>Mauvais format du numéro IDE, accepté : CHE-012.345.678 </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/account/new-order/steps/contact-pricing-step/contact-pricing-step.component.html</context>
-          <context context-type="linenumber">92</context>
+          <context context-type="linenumber">90</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7451848863370733592" datatype="html">
         <source>Téléphone mandant</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/account/new-order/steps/contact-pricing-step/contact-pricing-step.component.html</context>
-          <context context-type="linenumber">98</context>
+          <context context-type="linenumber">96</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1815195286714301387" datatype="html">
         <source>Adresse</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/account/new-order/steps/contact-pricing-step/contact-pricing-step.component.html</context>
-          <context context-type="linenumber">113</context>
+          <context context-type="linenumber">111</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6840029554610349837" datatype="html">
         <source>Complément d&apos;adresse</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/account/new-order/steps/contact-pricing-step/contact-pricing-step.component.html</context>
-          <context context-type="linenumber">118</context>
+          <context context-type="linenumber">116</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/account/profile/modify-profile.component.html</context>
@@ -185,7 +185,7 @@
         <source>Code postal</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/account/new-order/steps/contact-pricing-step/contact-pricing-step.component.html</context>
-          <context context-type="linenumber">123</context>
+          <context context-type="linenumber">121</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/account/profile/modify-profile.component.html</context>
@@ -204,7 +204,7 @@
         <source>Ville</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/account/new-order/steps/contact-pricing-step/contact-pricing-step.component.html</context>
-          <context context-type="linenumber">128</context>
+          <context context-type="linenumber">126</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/account/profile/modify-profile.component.html</context>
@@ -223,7 +223,7 @@
         <source>Pays</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/account/new-order/steps/contact-pricing-step/contact-pricing-step.component.html</context>
-          <context context-type="linenumber">133</context>
+          <context context-type="linenumber">131</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/account/profile/modify-profile.component.html</context>
@@ -242,7 +242,7 @@
         <source>Annuler</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/account/new-order/steps/contact-pricing-step/contact-pricing-step.component.ts</context>
-          <context context-type="linenumber">144</context>
+          <context context-type="linenumber">156</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/account/orders/order/order.component.ts</context>
@@ -261,7 +261,7 @@
         <source>Supprimer</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/account/new-order/steps/contact-pricing-step/contact-pricing-step.component.ts</context>
-          <context context-type="linenumber">145</context>
+          <context context-type="linenumber">157</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/account/orders/order/order.component.ts</context>
@@ -272,7 +272,7 @@
         <source>Etes-vous sûr de vouloir supprimer le contact &lt;b style=&apos;color:#26a59a;&apos;&gt;<x id="PH" equiv-text="contact.first_name"/> <x id="PH_1" equiv-text="contact.last_name"/>&lt;/b&gt; ?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/account/new-order/steps/contact-pricing-step/contact-pricing-step.component.ts</context>
-          <context context-type="linenumber">147</context>
+          <context context-type="linenumber">159</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1591895368052596259" datatype="html">
@@ -339,70 +339,70 @@
         <source>Titre du mandat</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/account/new-order/steps/order-type-step/order-type-step.component.html</context>
-          <context context-type="linenumber">18</context>
+          <context context-type="linenumber">19</context>
         </context-group>
       </trans-unit>
       <trans-unit id="8627725908406716847" datatype="html">
         <source> Le titre contient des caractères non supportés (parenthèses, guillemets, etc.)</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/account/new-order/steps/order-type-step/order-type-step.component.html</context>
-          <context context-type="linenumber">24</context>
+          <context context-type="linenumber">25</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1354754757426725771" datatype="html">
         <source>Description du mandat</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/account/new-order/steps/order-type-step/order-type-step.component.html</context>
-          <context context-type="linenumber">29</context>
+          <context context-type="linenumber">30</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5988593865166963203" datatype="html">
         <source>Renseigner une courte description du mandat...</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/account/new-order/steps/order-type-step/order-type-step.component.html</context>
-          <context context-type="linenumber">31</context>
+          <context context-type="linenumber">32</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4189701300328622803" datatype="html">
         <source>Votre référence reportée sur la facture</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/account/new-order/steps/order-type-step/order-type-step.component.html</context>
-          <context context-type="linenumber">39</context>
+          <context context-type="linenumber">40</context>
         </context-group>
       </trans-unit>
       <trans-unit id="4515716860476357376" datatype="html">
         <source>Choisir l&apos;email de livraison</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/account/new-order/steps/order-type-step/order-type-step.component.html</context>
-          <context context-type="linenumber">45</context>
+          <context context-type="linenumber">46</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5938060479305453476" datatype="html">
         <source>Les données seront envoyées à l&apos;adresse email de l&apos;utilisateur courant: <x id="INTERPOLATION" equiv-text="{{user?.email}}"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/account/new-order/steps/order-type-step/order-type-step.component.html</context>
-          <context context-type="linenumber">46</context>
+          <context context-type="linenumber">47</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1071751312378015303" datatype="html">
         <source>Adresse de livraison des données différente</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/account/new-order/steps/order-type-step/order-type-step.component.html</context>
-          <context context-type="linenumber">48</context>
+          <context context-type="linenumber">49</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5457045476183220490" datatype="html">
         <source>Saisir l&apos;adresse email de livraison</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/account/new-order/steps/order-type-step/order-type-step.component.html</context>
-          <context context-type="linenumber">52</context>
+          <context context-type="linenumber">53</context>
         </context-group>
       </trans-unit>
       <trans-unit id="785075939257175908" datatype="html">
         <source>Adresse email non valide</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/account/new-order/steps/order-type-step/order-type-step.component.html</context>
-          <context context-type="linenumber">57</context>
+          <context context-type="linenumber">58</context>
         </context-group>
       </trans-unit>
       <trans-unit id="order.delete" datatype="html">
@@ -1309,12 +1309,16 @@
           <context context-type="sourcefile">src/app/constants.ts</context>
           <context context-type="linenumber">53</context>
         </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/constants.ts</context>
+          <context context-type="linenumber">58</context>
+        </context-group>
       </trans-unit>
       <trans-unit id="search.category.unknown" datatype="html">
         <source>Général</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/constants.ts</context>
-          <context context-type="linenumber">60</context>
+          <context context-type="linenumber">61</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5300981229662517671" datatype="html">
@@ -1359,7 +1363,7 @@
           <context context-type="linenumber">234</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="8227723705151707399" datatype="html">
+      <trans-unit id="3236774620090971707" datatype="html">
         <source>Contact ajouté &quot;<x id="PH" equiv-text="contact.first_name"/> <x id="PH_1" equiv-text="contact.last_name"/>&quot;</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/services/api-order.service.ts</context>
@@ -1729,49 +1733,56 @@
         <source><x id="INTERPOLATION" equiv-text="{{item.product.id}}"/>. <x id="INTERPOLATION_1" equiv-text="{{item.product.label}}"/> - à valider</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/welcome/validate/validate.component.html</context>
-          <context context-type="linenumber">42</context>
+          <context context-type="linenumber">43</context>
         </context-group>
       </trans-unit>
       <trans-unit id="2747788433655367550" datatype="html">
         <source> Cette page permet d&apos;autoriser ou d&apos;annuler l&apos;utilisation d&apos;un produit commandé sur le geoshop. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/welcome/validate/validate.component.html</context>
-          <context context-type="linenumber">44</context>
+          <context context-type="linenumber">45</context>
         </context-group>
       </trans-unit>
       <trans-unit id="1272421211953350782" datatype="html">
         <source>Titre du mandat <x id="INTERPOLATION" equiv-text="{{order.order_type | lowercase}}"/>:</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/welcome/validate/validate.component.html</context>
-          <context context-type="linenumber">48</context>
+          <context context-type="linenumber">49</context>
         </context-group>
       </trans-unit>
       <trans-unit id="36900456667458058" datatype="html">
         <source>Description fournie par le client:</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/welcome/validate/validate.component.html</context>
-          <context context-type="linenumber">50</context>
+          <context context-type="linenumber">51</context>
         </context-group>
       </trans-unit>
       <trans-unit id="5648951943054133937" datatype="html">
         <source>Détails du client:</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/welcome/validate/validate.component.html</context>
-          <context context-type="linenumber">52</context>
+          <context context-type="linenumber">53</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7391218527938739133" datatype="html">
         <source>ACCEPTER</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/welcome/validate/validate.component.html</context>
-          <context context-type="linenumber">65</context>
+          <context context-type="linenumber">77</context>
         </context-group>
       </trans-unit>
       <trans-unit id="6754428430652088774" datatype="html">
         <source>REFUSER</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/welcome/validate/validate.component.html</context>
-          <context context-type="linenumber">66</context>
+          <context context-type="linenumber">78</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="1719424001991628872" datatype="html">
+        <source>Contact de facturation</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/welcome/validate/validate.component.html</context>
+          <context context-type="linenumber">64</context>
         </context-group>
       </trans-unit>
     </body>


### PR DESCRIPTION
Added contact information (if any) to the validation page. Displaying both user contact information and the billing contact information.
"Billing contact" translated as "Rechnungskontakt" and "Contact de facturation"
<img width="708" height="867" alt="with_contact" src="https://github.com/user-attachments/assets/f361dd65-39a9-4e94-b75f-84bc29f618f5" />

