### PR TITLE
fix(GSGGR-663): Make IDE number a string

### DIFF
--- a/src/app/account/profile/modify-profile.component.ts
+++ b/src/app/account/profile/modify-profile.component.ts
@@ -82,7 +82,7 @@ export class ModifyProfileComponent {
         city: this.formModifyUser.get('city')?.value ?? "",
         country: this.formModifyUser.get('country')?.value ?? "",
         company_name: this.formModifyUser.get('company_name')?.value ?? "",
-        ide_id: this.formModifyUser.get('ide_id')?.value ?? 0,
+        ide_id: this.formModifyUser.get('ide_id')?.value ?? "",
         phone: this.formModifyUser.get('phone')?.value ?? "",
       };
 

--- a/src/app/models/IIdentity.ts
+++ b/src/app/models/IIdentity.ts
@@ -19,7 +19,7 @@ export interface IIdentity {
   country?: string;
   phone?: string;
   sap_id?: number;
-  ide_id?: number;
+  ide_id?: string;
   birthday?: string;
   contract_accepted?: boolean;
   token?: string;

--- a/src/app/models/IUser.ts
+++ b/src/app/models/IUser.ts
@@ -13,7 +13,7 @@ export interface IUserToPost {
   city: string;
   country: string;
   company_name: string;
-  ide_id?: number;
+  ide_id?: string;
   phone: string;
 }
 
@@ -30,6 +30,6 @@ export interface IUser {
   city: string;
   country: string;
   company_name: string;
-  ide_id?: number;
+  ide_id?: string;
   phone: string;
 }


### PR DESCRIPTION
That helps django to handle empty IDE correctly.
Before: empty IDE sent as 0, django vaildation fails.
After: empty IDE sent as "", django allows empty strings.