### PR TITLE
fix (GSGGR-719): Area validation bug

### DIFF
--- a/src/app/interceptors/errorInterceptor.ts
+++ b/src/app/interceptors/errorInterceptor.ts
@@ -15,8 +15,8 @@ function formatArea(area: number): string {
     `${Math.round(area * 100) / 100}m²`;
 }
 
-function formatAreaError(err: { message: [string], excluded: [number], actual: [number] }): string {
-  return $localize`Selected area is too large, selected: ${formatArea(err.actual[0])}, overflow: ${formatArea(err.excluded[0])}`;
+function formatAreaError(err: { message: [string], expected: [number], actual: [number] }): string {
+  return $localize`Selected area is too large, selected: ${formatArea(err.actual[0])}, overflow: ${formatArea(err.actual[0] - err.expected[0])}`;
 }
 
 function formatConnectionError(response: HttpErrorResponse): string {

--- a/src/app/services/map.service.ts
+++ b/src/app/services/map.service.ts
@@ -42,7 +42,6 @@ import ImageWMS from 'ol/source/ImageWMS';
 import TileSource from 'ol/source/Tile';
 import VectorSource, { VectorSourceEvent } from 'ol/source/Vector';
 import WMTS, { Options } from 'ol/source/WMTS';
-import { getArea as getAreaSphere } from 'ol/sphere.js';
 import { Circle as CircleStyle, Fill, Stroke, Style } from 'ol/style';
 import WMTSTileGrid from 'ol/tilegrid/WMTS';
 // @ts-expect-error: plain js import
@@ -593,10 +592,12 @@ export class MapService {
       this.areaTooltipElement.style.visibility = "hidden";
       return
     }
-    let content = formatArea(getAreaSphere(geom));
+    // Use the planar LV95 (EPSG:2056) area — the same the backend
+    const planarArea = (geom as Polygon).getArea();
+    let content = formatArea(planarArea);
     if (status.error && !status.valid) {
       this.areaTooltipElement.classList.add('invalid');
-      content += `<br/> ${status.error.message[0]}: (By ${formatArea(status.error.excluded[0] - status.error.expected[0])})`;
+      content += $localize`Selected area is too large, selected: ${formatArea(status.error.actual[0])}, overflow: ${formatArea( status.error.actual[0] - status.error.expected[0])}`;
     }
     this.areaTooltipElement.style.visibility = "visible";
     this.areaTooltip.setPosition(getCenter(geom.getExtent()));
@@ -647,7 +648,7 @@ export class MapService {
       return;
     }
     const polygon = this.currentFeature.getGeometry() as Polygon;
-    const area = formatArea(getAreaSphere(polygon));
+    const area = formatArea(polygon.getArea());
     this.currentFeature.set('area', area);
     this.store.dispatch(updateGeometry({ geom: this.geoJsonFormatter.writeGeometry(polygon) }));
     if (fitMap) {

--- a/src/app/services/map.service.ts
+++ b/src/app/services/map.service.ts
@@ -597,7 +597,7 @@ export class MapService {
     let content = formatArea(planarArea);
     if (status.error && !status.valid) {
       this.areaTooltipElement.classList.add('invalid');
-      content += $localize`Selected area is too large, selected: ${formatArea(status.error.actual[0])}, overflow: ${formatArea( status.error.actual[0] - status.error.expected[0])}`;
+      content +=`<br/>` + $localize`Order area is too large, overflow: ${formatArea( status.error.actual[0] - status.error.expected[0])}`;
     }
     this.areaTooltipElement.style.visibility = "visible";
     this.areaTooltip.setPosition(getCenter(geom.getExtent()));

--- a/src/locale/messages.de.xlf
+++ b/src/locale/messages.de.xlf
@@ -243,11 +243,15 @@
         </context-group>
       </trans-unit>
       <trans-unit id="5300981229662517671" datatype="html">
-        <source>Selected area is too large, selected: <x id="PH" equiv-text="formatArea(err.actual[0])"/>, overflow: <x id="PH_1" equiv-text="formatArea(err.excluded[0])"/></source>
-        <target>Der ausgewählte Bereich ist zu gross. Ausgewählt ist <x id="PH" equiv-text="formatArea(err.actual[0])"/>, was die erlaubte Grösse um <x id="PH_1" equiv-text="formatArea(err.excluded[0])"/> überschreitet.</target>
+        <source>Selected area is too large, selected: <x id="PH" equiv-text="formatArea(err.actual[0])"/>, overflow: <x id="PH_1" equiv-text="formatArea(err.actual[0] - err.expected[0])"/></source>
+        <target state="new">Der ausgewählte Bereich ist zu gross. Ausgewählt ist <x id="PH" equiv-text="formatArea(err.actual[0])"/>, was die erlaubte Grösse um <x id="PH_1" equiv-text="formatArea(err.expected[0])"/> überschreitet.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/interceptors/errorInterceptor.ts</context>
           <context context-type="linenumber">19</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/services/map.service.ts</context>
+          <context context-type="linenumber">600</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7356921708715046963" datatype="html">

--- a/src/locale/messages.de.xlf
+++ b/src/locale/messages.de.xlf
@@ -249,10 +249,6 @@
           <context context-type="sourcefile">src/app/interceptors/errorInterceptor.ts</context>
           <context context-type="linenumber">19</context>
         </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/services/map.service.ts</context>
-          <context context-type="linenumber">600</context>
-        </context-group>
       </trans-unit>
       <trans-unit id="7356921708715046963" datatype="html">
         <source>Unexpected error: <x id="PH" equiv-text="response.message"/></source>
@@ -2046,6 +2042,14 @@
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/account/profile/modify-profile.component.ts</context>
           <context context-type="linenumber">94</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="3558275494178084348" datatype="html">
+        <source>Order area is too large, overflow: <x id="PH" equiv-text="formatArea( status.error.actual[0] - status.error.expected[0])"/></source>
+        <target state="new">Order area is too large, overflow: <x id="PH" equiv-text="formatArea( status.error.actual[0] - status.error.expected[0])"/></target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/services/map.service.ts</context>
+          <context context-type="linenumber">600</context>
         </context-group>
       </trans-unit>
     </body>

--- a/src/locale/messages.en.xlf
+++ b/src/locale/messages.en.xlf
@@ -1673,10 +1673,6 @@
           <context context-type="sourcefile">src/app/interceptors/errorInterceptor.ts</context>
           <context context-type="linenumber">19</context>
         </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/services/map.service.ts</context>
-          <context context-type="linenumber">600</context>
-        </context-group>
       </trans-unit>
       <trans-unit id="7356921708715046963" datatype="html">
         <source>Unexpected error: <x id="PH" equiv-text="response.message"/></source>
@@ -2034,6 +2030,14 @@
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/account/profile/modify-profile.component.ts</context>
           <context context-type="linenumber">94</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="3558275494178084348" datatype="html">
+        <source>Order area is too large, overflow: <x id="PH" equiv-text="formatArea( status.error.actual[0] - status.error.expected[0])"/></source>
+        <target state="new">Order area is too large, overflow: <x id="PH" equiv-text="formatArea( status.error.actual[0] - status.error.expected[0])"/></target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/services/map.service.ts</context>
+          <context context-type="linenumber">600</context>
         </context-group>
       </trans-unit>
     </body>

--- a/src/locale/messages.en.xlf
+++ b/src/locale/messages.en.xlf
@@ -1667,11 +1667,15 @@
         </context-group>
       </trans-unit>
       <trans-unit id="5300981229662517671" datatype="html">
-        <source>Selected area is too large, selected: <x id="PH" equiv-text="formatArea(err.actual[0])"/>, overflow: <x id="PH_1" equiv-text="formatArea(err.excluded[0])"/></source>
-        <target state="new">Selected area is too large, selected: <x id="PH" equiv-text="formatArea(err.actual[0])"/>, overflow: <x id="PH_1" equiv-text="formatArea(err.excluded[0])"/></target>
+        <source>Selected area is too large, selected: <x id="PH" equiv-text="formatArea(err.actual[0])"/>, overflow: <x id="PH_1" equiv-text="formatArea(err.actual[0] - err.expected[0])"/></source>
+        <target state="new">Selected area is too large, selected: <x id="PH" equiv-text="formatArea(err.actual[0])"/>, overflow: <x id="PH_1" equiv-text="formatArea(err.actual[0] - err.expected[0])"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/interceptors/errorInterceptor.ts</context>
           <context context-type="linenumber">19</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/services/map.service.ts</context>
+          <context context-type="linenumber">600</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7356921708715046963" datatype="html">

--- a/src/locale/messages.xlf
+++ b/src/locale/messages.xlf
@@ -1320,10 +1320,6 @@
           <context context-type="sourcefile">src/app/interceptors/errorInterceptor.ts</context>
           <context context-type="linenumber">19</context>
         </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/services/map.service.ts</context>
-          <context context-type="linenumber">600</context>
-        </context-group>
       </trans-unit>
       <trans-unit id="7356921708715046963" datatype="html">
         <source>Unexpected error: <x id="PH" equiv-text="response.message"/></source>
@@ -1814,6 +1810,13 @@
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/account/profile/modify-profile.component.ts</context>
           <context context-type="linenumber">94</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="3558275494178084348" datatype="html">
+        <source>Order area is too large, overflow: <x id="PH" equiv-text="formatArea( status.error.actual[0] - status.error.expected[0])"/></source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/services/map.service.ts</context>
+          <context context-type="linenumber">600</context>
         </context-group>
       </trans-unit>
     </body>

--- a/src/locale/messages.xlf
+++ b/src/locale/messages.xlf
@@ -1315,10 +1315,14 @@
         </context-group>
       </trans-unit>
       <trans-unit id="5300981229662517671" datatype="html">
-        <source>Selected area is too large, selected: <x id="PH" equiv-text="formatArea(err.actual[0])"/>, overflow: <x id="PH_1" equiv-text="formatArea(err.excluded[0])"/></source>
+        <source>Selected area is too large, selected: <x id="PH" equiv-text="formatArea(err.actual[0])"/>, overflow: <x id="PH_1" equiv-text="formatArea(err.actual[0] - err.expected[0])"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/interceptors/errorInterceptor.ts</context>
           <context context-type="linenumber">19</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/services/map.service.ts</context>
+          <context context-type="linenumber">600</context>
         </context-group>
       </trans-unit>
       <trans-unit id="7356921708715046963" datatype="html">


### PR DESCRIPTION
- Changes the area calculation to match the one in the backend
- Sets the error message displayed on the polygon as a translatable field (translation in german to be added next)
- Fix the snackbar error message to display the correct overflow value (`err.actual[0] - err.expected[0]`)